### PR TITLE
Add ParseMultiplication to hp condition

### DIFF
--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -141,3 +141,17 @@ end
 function Util.ParseQuality(value)
     return value and PET_QUALITIES[lower(value)] or nil
 end
+
+function Util.ParseMultiplication(value)
+    if 'string' == type(value) then
+        local values, newvalue = {strsplit('*', value)}, 1
+
+        for i, v in ipairs(values) do
+            v = Util.assert(tonumber(v:trim()), 'Invalid Numerical: `%s` in `%s`', v, value)
+            newvalue = newvalue * v
+        end
+        return floor(newvalue)
+    else
+        return value
+    end
+end

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -44,7 +44,7 @@ Addon:RegisterCondition('dead', { type = 'boolean', arg = false }, function(owne
 end)
 
 
-Addon:RegisterCondition('hp', { type = 'compare', arg = false }, function(owner, pet)
+Addon:RegisterCondition('hp', { type = 'compare', arg = false, valueParse = Util.ParseMultiplication }, function(owner, pet)
     return C_PetBattles.GetHealth(owner, pet)
 end)
 


### PR DESCRIPTION
Introduces multiplication in the `hp` condition to aid with checking what an ability hits for after modifiers.
For example with a Mechanical Yeti's Ion Cannon being cast during Lightning Storm on a boss with the 50% reduced damage aura a script like below would ensure Ion Cannon is only cast when it kills.

```
use(Call Lightning:204)
use(Ion Cannon:209) [ enemy.hp <= 732 * 1.25 * 0.5 ]
use(Metal Fist:384)
```