### PR TITLE
add `collected.count` and `collected.max`

### DIFF
--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -202,6 +202,18 @@ Addon:RegisterCondition('collected', { type = 'boolean', arg = false }, function
     return select(2, C_PetJournal.FindPetIDByName(name)) ~= nil
 end)
 
+Addon:RegisterCondition('collected.count', { type = 'compare', arg = false }, function(owner, pet)
+    local species = C_PetJournal.FindPetIDByName(select(2, C_PetBattles.GetName(owner, pet)))
+    local collected = C_PetJournal.GetNumCollectedInfo(species)
+    return collected
+end)
+
+Addon:RegisterCondition('collected.max', { type = 'compare', arg = false }, function(owner, pet)
+    local species = C_PetJournal.FindPetIDByName(select(2, C_PetBattles.GetName(owner, pet)))
+    local max = select(2, C_PetJournal.GetNumCollectedInfo(species))
+    return max
+end)
+
 Addon:RegisterCondition('trap', { type = 'boolean', owner = false , pet = false, arg = false }, function()
     local usable, err = C_PetBattles.IsTrapAvailable()
     return usable or (not usable and err == 4)

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -204,14 +204,24 @@ end)
 
 Addon:RegisterCondition('collected.count', { type = 'compare', arg = false }, function(owner, pet)
     local species = C_PetJournal.FindPetIDByName(select(2, C_PetBattles.GetName(owner, pet)))
-    local collected = C_PetJournal.GetNumCollectedInfo(species)
-    return collected
+    local obtainable = species and select(11, C_PetJournal.GetPetInfoBySpeciesID(species))
+
+    if not obtainable then
+        return 0
+    end
+
+    return species and select(1, C_PetJournal.GetNumCollectedInfo(species)) or 0
 end)
 
 Addon:RegisterCondition('collected.max', { type = 'compare', arg = false }, function(owner, pet)
     local species = C_PetJournal.FindPetIDByName(select(2, C_PetBattles.GetName(owner, pet)))
-    local max = select(2, C_PetJournal.GetNumCollectedInfo(species))
-    return max
+    local obtainable = species and select(11, C_PetJournal.GetPetInfoBySpeciesID(species))
+    
+    if not obtainable then
+        return 0
+    end
+
+    return species and select(2, C_PetJournal.GetNumCollectedInfo(species)) or 0
 end)
 
 Addon:RegisterCondition('trap', { type = 'boolean', owner = false , pet = false, arg = false }, function()


### PR DESCRIPTION
Adds a `collected.count` and a `collected.max` condition that return the amount of pets captured and the max available to capture respectively.

This adds more of the functionality that was asked for on tdbattlescripts to manage capturing. It lets you figure out how many pets you have captured and then go from there. I'm not entirely sure why someone would want `collected.max` since this is only really useful for wild pet capture, but I included it for completeness.

Example:

```
if [enemy.collected.count < 3]
   ...
endif
```

I'm still hoping to figure out how to implement `self.collected.quality.min` or similar, but it's currently looking like that will require scanning the entire pet journal, which I'm hoping to avoid.