### PR TITLE
conditions: let `type` explicitly handle nil pet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed issue with Test button not correctly disabling during pet battle animations
 - Fixed issue where the Test button crashed on if/endif blocks in the script.
+- Fixed condition (pet) `type` to correctly handle bad pets (e.g. `self(#4).type`) again.
 
 ## v1.3
 

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -174,7 +174,7 @@ end)
 
 
 Addon:RegisterCondition('type', { type = 'equality', arg = false, valueParse = Util.ParsePetType }, function(owner, pet)
-    return C_PetBattles.GetPetType(owner, pet)
+    return pet and C_PetBattles.GetPetType(owner, pet)
 end)
 
 


### PR DESCRIPTION
Apparently the API call now just interprets `nil = 0`, thus always returns a (bogus) type.