### PR TITLE
conditions: allow using math in compare-conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fixed issue with Test button not correctly disabling during pet battle animations
 - Fixed issue where the Test button crashed on if/endif blocks in the script.
 - Fixed condition (pet) `type` to correctly handle bad pets (e.g. `self(#4).type`) again.
-- Allow using math within "compare" conditions, like `hp` or `speed`. Basic math operations like `+-*/%()` are available. Additionally the functions `ceil()` and `floor()`, `abs()`, `min(a, b)` and `max(a, b)`, `cond(c, yes, no)` and `clamp(v, min, max)` can be used.
+- Allow using math within "compare" conditions, like `hp` or `speed`. Basic math operations like `+-*/%()` are available. Additionally the functions `ceil()` and `floor()`, `abs()`, `min(a, b)` and `max(a, b)` can be used.
 
 ## v1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed issue with Test button not correctly disabling during pet battle animations
 - Fixed issue where the Test button crashed on if/endif blocks in the script.
 - Fixed condition (pet) `type` to correctly handle bad pets (e.g. `self(#4).type`) again.
+- Allow using math within "compare" conditions, like `hp` or `speed`. Basic math operations like `+-*/%()` are available. Additionally the functions `ceil()` and `floor()`, `abs()`, `min(a, b)` and `max(a, b)`, `cond(c, yes, no)` and `clamp(v, min, max)` can be used.
 
 ## v1.3
 

--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -149,8 +149,6 @@ local mathParserEnv = {
     abs = math.abs,
     min = math.min,
     max = math.max,
-    cond = function(conditional, onTrue, onFalse) if ( conditional ) then return onTrue; else return onFalse; end end,
-    clamp = function(value, minClamp, maxClamp) return min(max(value, minClamp), maxClamp); end,
 }
 
 local mathParserSafeEnv = {}

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -44,7 +44,7 @@ Addon:RegisterCondition('dead', { type = 'boolean', arg = false }, function(owne
 end)
 
 
-Addon:RegisterCondition('hp', { type = 'compare', arg = false }, function(owner, pet)
+Addon:RegisterCondition('hp', { type = 'compare', arg = false, valueParse = Util.ParseNumberWithMath }, function(owner, pet)
     return C_PetBattles.GetHealth(owner, pet)
 end)
 
@@ -69,7 +69,7 @@ Addon:RegisterCondition('hp.high', { type = 'boolean', pet = false, arg = false 
 end)
 
 
-Addon:RegisterCondition('hpp', { type = 'compare', arg = false }, function(owner, pet)
+Addon:RegisterCondition('hpp', { type = 'compare', arg = false, valueParse = Util.ParseNumberWithMath }, function(owner, pet)
     return C_PetBattles.GetHealth(owner, pet) / logical_max_health(owner, pet) * 100
 end)
 
@@ -153,9 +153,9 @@ Addon:RegisterCondition('played', { type = 'boolean', arg = false }, function(ow
     return pet and Played:IsPetPlayed(owner, pet)
 end)
 
-Addon:RegisterCondition('speed', { type = 'compare', arg = false }, C_PetBattles.GetSpeed)
-Addon:RegisterCondition('power', { type = 'compare', arg = false }, C_PetBattles.GetPower)
-Addon:RegisterCondition('level', { type = 'compare', arg = false }, C_PetBattles.GetLevel)
+Addon:RegisterCondition('speed', { type = 'compare', arg = false, valueParse = Util.ParseNumberWithMath }, C_PetBattles.GetSpeed)
+Addon:RegisterCondition('power', { type = 'compare', arg = false, valueParse = Util.ParseNumberWithMath }, C_PetBattles.GetPower)
+Addon:RegisterCondition('level', { type = 'compare', arg = false, valueParse = Util.ParseNumberWithMath }, C_PetBattles.GetLevel)
 
 
 Addon:RegisterCondition('level.max', { type = 'boolean', arg = false }, function(owner, pet)


### PR DESCRIPTION
This changeset allows writing scripts with more complex math, like #10, but with more operations

```
test(self.speed > clamp(1, 2, 3)) [ self.speed > clamp(1, 2, 3) ]
test(self.hp > cond(false, 1200, 10)) [ self.hp > cond(false, 1200, 10) ]
test(self.hp > ceil(1.5*floor (3/2))) [self.hp > ceil(1.5*floor(3/2)) ]
test(self.hp > 3%2) [ self.hp > 3%2 ]
test(self.hp > 1*2/3-4+5) [self.hp > 1*2/3-4+5]

use(Call Lightning:204)
use(Ion Cannon:209) [ enemy.hp <= (732 * 1.25) / 2 ]
use(Metal Fist:384)
```