### PR TITLE
Changes can_explode calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.6
 
 - Updated readme to reflect an issue with `Rematch` when uninstalling `tdBattlePetScript`
+- Updated calculation for can_explode, to use "<=" instead of "<"
 
 ## v1.5
 

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -55,7 +55,7 @@ end)
 
 
 Addon:RegisterCondition('hp.can_explode', { type = 'boolean', arg = false }, function(owner, pet)
-    return pet and C_PetBattles.GetHealth(owner, pet) < floor(logical_max_health(getOpponentActivePet(owner)) * 0.4)
+    return pet and C_PetBattles.GetHealth(owner, pet) <= floor(logical_max_health(getOpponentActivePet(owner)) * 0.4)
 end)
 
 


### PR DESCRIPTION
Currently, the calculation for can_explode checks if the opponents health is below 40% .
It should be at or below, instead of just below, since if it is at the exact amount, it will still hit 0.

This fixes #14

Code is provided by cosinussinus on github