### PR TITLE
Return false in RunCondition if argParse returned nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.6
 
 - Updated readme to reflect an issue with `Rematch` when uninstalling `tdBattlePetScript`
+- Fixed issue with ability conditions passing when a pet does not have the ability.
 
 ## v1.5
 

--- a/Core/Condition.lua
+++ b/Core/Condition.lua
@@ -105,7 +105,11 @@ function Condition:Run(condition)
 end
 
 function Condition:RunCondition(condition)
-    local owner, pet, cmd, arg, op, value = self:ParseCondition(condition)
+    local owner, pet, cmd, arg, op, value, validCondition = self:ParseCondition(condition)
+
+    if not validCondition then
+        return false
+    end
 
     local fn  = self.apis[cmd]
     local opts = self.opts[cmd]
@@ -177,6 +181,8 @@ function Condition:ParseCondition(condition)
 
     local owner, pet, cmd, arg, petInputed, argInputed = self:ParseApi(args:trim())
 
+    local validCondition = true
+
     Util.assert(cmd, 'Invalid Condition: `%s` (Can`t parse)', condition)
     Util.assert(self.apis[cmd], 'Invalid Condition: `%s` (Not found cmd: `%s`)', condition, cmd)
 
@@ -236,7 +242,11 @@ function Condition:ParseCondition(condition)
         arg = trynumber(arg)
         if opts.argParse then
             arg = opts.argParse(owner, pet, arg)
+            if arg == nil then
+                -- Invalidate the condition if argParse is provided but it returned a nil
+                validCondition = false
+            end
         end
     end
-    return owner, pet, cmd, arg, op, value
+    return owner, pet, cmd, arg, op, value, validCondition
 end


### PR DESCRIPTION
argParse is currently only used by ability condition, so as far as I can see it's correct to always invalidate the entire condition if the argParser didn't return anything.

See #17 