### PR TITLE
conditions: add hp.diff and hpp.diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.9
+
+### New features
+
+- Added condition `hp.diff` and `hpp.diff` allowing to compare own and enemy pet HP. `hp.diff = self.hp - enemy.hp` and `hpp.diff = self.hpp - enemy.hpp`. This can be used as condition for abilities that do more than one effect but use a condition after a subset of those effects (i.e. "does double damage if health difference is bigger than x after first damage effect").
+
 ## v1.8
 
 - Restored the full set of configuration options. They were removed when the tdPetBattleScript and tdPetBattleScript_Rematch addons were merged.

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -69,8 +69,22 @@ Addon:RegisterCondition('hp.high', { type = 'boolean', pet = false, arg = false 
 end)
 
 
-Addon:RegisterCondition('hpp', { type = 'compare', arg = false }, function(owner, pet)
+local function hpp(owner, pet)
     return C_PetBattles.GetHealth(owner, pet) / logical_max_health(owner, pet) * 100
+end
+
+Addon:RegisterCondition('hpp', { type = 'compare', arg = false }, function(owner, pet)
+    return hpp(owner, pet)
+end)
+
+
+Addon:RegisterCondition('hp.diff', { type = 'compare', arg = false }, function(owner, pet)
+    return C_PetBattles.GetHealth(owner, pet) - C_PetBattles.GetHealth(getOpponentActivePet(owner))
+end)
+
+
+Addon:RegisterCondition('hpp.diff', { type = 'compare', arg = false }, function(owner, pet)
+    return hpp(owner, pet) - hpp(getOpponentActivePet(owner))
 end)
 
 


### PR DESCRIPTION
Abilities like [Early Advantage](https://www.wowhead.com/pet-ability=405/early-advantage) seem to work with `hp.low`, but the wording is misleading as seen in the first comment on wowhead: The condition is evaluated only after dealing damage once. Since the user can't change the turn after making it, the scripts addon obviously can't defer evaluating the condition to after half the move was made. I would also prefer not to add specific support for this type of ability.

Instead, @patf0rd suggested to expand `hp.low` to not just provide `>` and `<` (which can already be done with `self.hp < enemy.hp`, no idea why the shortcut was added tbh), but also provide comparison of the health *difference*, i.e. `hp.diff > 277 & !ability.strong` in this case.

The options are
- as mentioned, `hp.diff` to be used in comparisons. This might be slightly weird to use since of course there would be `self.hp.diff` and `enemy.hp.diff` being the same but the other way around.
- The full fledged support for mathematical expressions, which would allow `(self.hp - enemy.hp) > 277`. Note that this also makes `hp.can_explode(15)` irrelevant as it can just be `enemy.hp <= self.hp.max * 0.15`.

I have toyed with the second suggestion before (#13), but fully implementing it would require some bigger backend changes and I'm not sure anyone but me would actually care about that feature, so I don't want to put that much effort into this.