### PR TITLE
Condition: 'ability.duration' include all cooldowns (e.g. Nevermore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.9
+
+### Fixes
+
+- The condition `ability.duration` now correctly also takes lockdowns (not cooldowns!) into account.
+
 ## v1.8
 
 - Restored the full set of configuration options. They were removed when the tdPetBattleScript and tdPetBattleScript_Rematch addons were merged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - The condition `ability.duration` now correctly also takes lockdowns (not cooldowns!) into account.
+- If the same ability is available multiple times, the instance with the shortest cooldown **and** lockdown is chosen now.
 
 ## v1.8
 

--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -69,7 +69,8 @@ function Util.ParseAbility(owner, pet, ability)
         for i = 1, NUM_BATTLE_PET_ABILITIES do
             local id, name = C_PetBattles.GetAbilityInfo(owner, pet, i)
             if id == tonumber(ability) or name == ability then
-                local usable, duration = C_PetBattles.GetAbilityState(owner, pet, i)
+                local usable, currentCooldown, currentLockdown = C_PetBattles.GetAbilityState(owner, pet, i)
+                local duration = max(currentCooldown, currentLockdown)
                 if usable then
                     return i
                 end

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -120,7 +120,7 @@ end)
 
 Addon:RegisterCondition('ability.duration', { type = 'compare', argParse = Util.ParseAbility }, function(owner, pet, ability)
     local isUsable, currentCooldown, currentLockdown = C_PetBattles.GetAbilityState(owner, pet, ability)
-    return ability and currentCooldown or infinite
+    return ability and max(currentCooldown, currentLockdown) or infinite
 end)
 
 


### PR DESCRIPTION
Abilities like Nevermore lock an ability and give it an internal cooldown. The change takes these abilities into account.