### PR TITLE
Fix for #51

### DIFF
--- a/Extension/Snippets.lua
+++ b/Extension/Snippets.lua
@@ -159,17 +159,7 @@ function Snippets:ParseCondition(condition)
         return
     end
 
-    local non do
-        local _cond
-        non, _cond = condition:match('^(!?)%s*(.+)$')
-        non = non == '!'
-
-        if non then
-            condition = _cond
-        end
-    end
-
-    local owner, pet, cmd, arg, petInputed, argInputed = Condition:ParseApi(condition)
+    local non, owner, pet, cmd, arg, _, _, petInputed, argInputed = Condition:ParseApi(condition)
 
     return owner, pet, cmd, arg, non, petInputed, argInputed
 end


### PR DESCRIPTION
Expanded `Condition:ParseApi` to now parse more data, as a Lua the pattern wont cut it.

The method will now, on top of ignoring special characters in spell names, return the non (!), operator and any values.  

Just noticed that there's a side effect from trying to trimming the spaces between the condition command and operators, that it now allows spaces around the periods in the condition command. Doesn't seem to affect the snippets from writing script. 