### PR TITLE
Condition: Owner and Value Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.9
+
+### Breaking Changes
+- Conditions that require to specify a pet now correctly check that. `[ hp > 1 ]` was never valid and thus never true, but did not provoke an error to hint users to change it to `[ self.hp > 1 ]`. This change only breaks scripts that are currently silently broken already.
+
+### Fixes
+- Add missing check that conditions with comparisons compare against numbers.
+
 ## v1.8
 
 - Restored the full set of configuration options. They were removed when the tdPetBattleScript and tdPetBattleScript_Rematch addons were merged.

--- a/Core/Condition.lua
+++ b/Core/Condition.lua
@@ -12,10 +12,11 @@ local Condition = {} ns.Condition = Condition
 Condition.apis = {}
 Condition.opts = setmetatable({
     __default = {
-        owner = true,
+        owner = 'required',
         pet   = true,
         arg   = true,
         type  = 'compare',
+        valueParse = Util.ParseIsNumber,
     }
 }, {
     __newindex = function(t, k, v)
@@ -61,6 +62,12 @@ local parses = {
     'argParse',
 }
 
+local ownerOptions = {
+    ['required'] = true,
+    ['not-allowed'] = true,
+    ['optional'] = true,
+}
+
 local function trynumber(value)
     return tonumber(value) or value
 end
@@ -73,6 +80,10 @@ function Addon:RegisterCondition(name, opts, api)
     if opts then
         if opts.type and not opTabler[opts.type] then
             error([[Bad argument opts.type (expect compare/boolean/equality)]], 2)
+        end
+
+        if opts.owner and not ownerOptions[opts.owner] then
+            error([[Bad argument opts.owner (expect required/not-allowed/optional)]], 2)
         end
 
         for i, v in ipairs(parses) do
@@ -222,7 +233,11 @@ function Condition:ParseCondition(condition)
         end
     end
 
-    if not opts.owner then
+    if opts.owner == 'required' then
+        Util.assert(owner, 'Invalid Condition: `%s` (Needs owner)', condition)
+    end
+
+    if opts.owner == 'not-allowed' then
         Util.assert(not owner, 'Invalid Condition: `%s` (Not need owner)', condition)
     end
 

--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -141,3 +141,7 @@ end
 function Util.ParseQuality(value)
     return value and PET_QUALITIES[lower(value)] or nil
 end
+
+function Util.ParseIsNumber(value)
+    return tonumber(value)
+end

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -88,7 +88,7 @@ Addon:RegisterCondition('aura.duration', { type = 'compare' }, function(owner, p
 end)
 
 
-Addon:RegisterCondition('weather', { type = 'boolean', owner = false, pet = false }, function(_, _, weather)
+Addon:RegisterCondition('weather', { type = 'boolean', owner = 'not-allowed', pet = false }, function(_, _, weather)
     local id, name = 0, ''
     local aura = C_PetBattles.GetAuraInfo(Enum.BattlePetOwner.Weather, PET_BATTLE_PAD_INDEX, 1)
     if aura then
@@ -98,7 +98,7 @@ Addon:RegisterCondition('weather', { type = 'boolean', owner = false, pet = fals
 end)
 
 
-Addon:RegisterCondition('weather.duration', { type = 'compare', owner = false, pet = false }, function(_, _, weather)
+Addon:RegisterCondition('weather.duration', { type = 'compare', owner = 'not-allowed', pet = false }, function(_, _, weather)
     local id, _, duration = C_PetBattles.GetAuraInfo(Enum.BattlePetOwner.Weather, PET_BATTLE_PAD_INDEX, 1)
     if weather and id and (id == weather or select(2, C_PetBattles.GetAbilityInfoByID(id)) == weather) then
         return duration
@@ -141,7 +141,7 @@ Addon:RegisterCondition('ability.type', { type = 'equality', argParse = Util.Par
 end)
 
 
-Addon:RegisterCondition('round', { type = 'compare', pet = false, arg = false }, function(owner)
+Addon:RegisterCondition('round', { type = 'compare', owner='optional', pet = false, arg = false }, function(owner)
     if owner then
         return Round:GetRoundByOwner(owner)
     else
@@ -224,7 +224,7 @@ Addon:RegisterCondition('collected.max', { type = 'compare', arg = false }, func
     return species and select(2, C_PetJournal.GetNumCollectedInfo(species)) or 0
 end)
 
-Addon:RegisterCondition('trap', { type = 'boolean', owner = false , pet = false, arg = false }, function()
+Addon:RegisterCondition('trap', { type = 'boolean', owner = 'not-allowed', pet = false, arg = false }, function()
     local usable, err = C_PetBattles.IsTrapAvailable()
     return usable or (not usable and err == 4)
 end)


### PR DESCRIPTION
#**1. Owner**

Currently conditions without owner are all valid. But a condition like hp, exists, dead ... require an owner. It doesn't make any sense without it. Essentially there are three options:
Owner is **required** (on default):
```
dead, hp, hp.full, hp.can_explode, hp.low, hp.high, hpp, aura.exists, aura.duration, active, ability.usable, ability.duration, ability.strong, ability.weak, ability.type, played, speed, power, level, level.max, speed.fast, speed.slow, type, quality, exists, is, id, collected, collected.count, collected.max
```
Owner is **not allowed**:
```
weather, weather.duration, trap
```
Owner is **optional**:
```
round
```


**2. Value**

The only values currently being checked are:
```
ability.type, type, quality
```

Values are not checked at all:
```
hp, hpp, aura.duration, weather.duration, ability.duration, round, speed, power, level, collected.count, collected.max, id
```

I suggest setting the default to check whether it is actually a number. You can change the value options at any time through a custom function.


It will also fix this issue https://github.com/axc450/pbs/issues/35#issue-1688846625

