### PR TITLE
condition: aliases for hp.can_explode and weather, fix auto-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 
 - Added condition `hp.diff` and `hpp.diff` allowing to compare own and enemy pet HP. `hp.diff = self.hp - enemy.hp` and `hpp.diff = self.hpp - enemy.hpp`. This can be used as condition for abilities that do more than one effect but use a condition after a subset of those effects (i.e. "does double damage if health difference is bigger than x after first damage effect").
+- An alias `hp.can_be_exploded` has been added which is equivalent to `hp.can_explode` but phrased less confusingly. Prefer this in new scripts for clarity.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added condition `hp.diff` and `hpp.diff` allowing to compare own and enemy pet HP. `hp.diff = self.hp - enemy.hp` and `hpp.diff = self.hpp - enemy.hpp`. This can be used as condition for abilities that do more than one effect but use a condition after a subset of those effects (i.e. "does double damage if health difference is bigger than x after first damage effect").
 - An alias `hp.can_be_exploded` has been added which is equivalent to `hp.can_explode` but phrased less confusingly. Prefer this in new scripts for clarity.
+- An alias `weather(x).exists` has been added which is equivalent to `weather(x)` but more verbose.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - The condition `ability.duration` now correctly also takes lockdowns (not cooldowns!) into account.
 - Add missing check that conditions with comparisons compare against numbers.
+- Script editor auto completion now correctly offers `weather`, `weather.duration` and `trap` and no longer offers the wrong `self.weather`.
 - If the same ability is available multiple times, the instance with the shortest cooldown **and** lockdown is chosen now.
 
 ## v1.8

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -103,7 +103,7 @@ Addon:RegisterCondition('aura.duration', { type = 'compare' }, function(owner, p
 end)
 
 
-Addon:RegisterCondition('weather', { type = 'boolean', owner = 'not-allowed', pet = false }, function(_, _, weather)
+Addon:RegisterCondition('weather.exists', { type = 'boolean', owner = 'not-allowed', pet = false }, function(_, _, weather)
     local id, name = 0, ''
     local aura = C_PetBattles.GetAuraInfo(Enum.BattlePetOwner.Weather, PET_BATTLE_PAD_INDEX, 1)
     if aura then
@@ -111,6 +111,7 @@ Addon:RegisterCondition('weather', { type = 'boolean', owner = 'not-allowed', pe
     end
     return weather and (id == weather or name == weather)
 end)
+Addon:RegisterCondition('weather', ns.Condition.opts['weather.exists'], ns.Condition.apis['weather.exists'])
 
 
 Addon:RegisterCondition('weather.duration', { type = 'compare', owner = 'not-allowed', pet = false }, function(_, _, weather)

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -242,5 +242,5 @@ end)
 
 Addon:RegisterCondition('trap', { type = 'boolean', owner = 'not-allowed', pet = false, arg = false }, function()
     local usable, err = C_PetBattles.IsTrapAvailable()
-    return usable or (not usable and err == 4)
+    return usable or (not usable and err == 4) -- 4 = PETBATTLE_TRAPSTATUS_CANT_TRAP_TOO_MUCH_HEALTH
 end)

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -54,9 +54,10 @@ Addon:RegisterCondition('hp.full', { type = 'boolean', arg = false }, function(o
 end)
 
 
-Addon:RegisterCondition('hp.can_explode', { type = 'boolean', arg = false }, function(owner, pet)
+Addon:RegisterCondition('hp.can_be_exploded', { type = 'boolean', arg = false }, function(owner, pet)
     return pet and C_PetBattles.GetHealth(owner, pet) <= floor(logical_max_health(getOpponentActivePet(owner)) * 0.4)
 end)
+Addon:RegisterCondition('hp.can_explode', ns.Condition.opts['hp.can_be_exploded'], ns.Condition.apis['hp.can_be_exploded'])
 
 
 Addon:RegisterCondition('hp.low', { type = 'boolean', pet = false, arg = false }, function(owner, pet)

--- a/Extension/Snippets.lua
+++ b/Extension/Snippets.lua
@@ -76,7 +76,12 @@ do
             end
 
             local opts = Condition.opts[v]
-            if not opts.owner ~= not owner and v ~= 'round' then
+
+            local requiresOwner = opts.owner == 'required'
+            local forbidsOwner = opts.owner == 'not-allowed'
+            local hasOwner = not not owner
+
+            if (requiresOwner and not hasOwner) or (forbidsOwner and hasOwner) then
                 return false
             end
             if opts.pet and not pet then


### PR DESCRIPTION
- Add condition alias for readability: `enemy.hp.can_be_exploded` to at some point replace `enemy.hp.can_explode` (which is worded the wrong way around).
- Add condition alias for readability: `weather(x).exists` instead of just `weather(x)`. 
- Fix auto-completion for `weather` and `trap`. 

```diff
-### `hp.can_explode`
+### `hp.can_be_exploded` (or `hp.can_explode`)
 If the damage from the opponent pet self-destructing would kill the given pet.
 
 **Return**: `bool`  
-**Examples**: `enemy.hp.can_explode` (will the `enemy` pet die if the `self` pet explodes?) or `self.hp.can_explode` (will the `self` pet die if the `enemy` pet explodes?)  
-**Note**: You will likely always want to use `use(explosion) [ enemy.hp.can_explode ]`
+**Examples**: `enemy.hp.can_be_exploded` (will the `enemy` pet die if the `self` pet explodes?) or `self.hp.can_be_exploded` (will the `self` pet die if the `enemy` pet explodes?)  
+**Note**: You will likely always want to use `use(explosion) [ enemy.hp.can_be_exploded ]`. Old scripts will be using `enemy.hp.can_explode` which is equivalent, but should be avoided due to being harder to understand.
```

```diff
-### `weather`
+### `weather.exists` (or `weather`)
 If a weather effect is currently active.

 **Selectors**: `Name`, `ID`  
 **Return**: `bool`  
-**Examples**: `weather(Moonlight).exists`, `weather(#596)`
+**Examples**: `weather(Moonlight:596).exists` or `weather(Moonlight:596)`
```