### PR TITLE
Fixes for Patch 10.2 PTR

### DIFF
--- a/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -1,13 +1,13 @@
 --- AceConfigDialog-3.0 generates AceGUI-3.0 based windows based on option tables.
 -- @class file
 -- @name AceConfigDialog-3.0
--- @release $Id: AceConfigDialog-3.0.lua 1292 2022-09-29 08:00:11Z nevcairiel $
+-- @release $Id: AceConfigDialog-3.0.lua 1296 2022-11-04 18:50:10Z nevcairiel $
 
 local LibStub = LibStub
 local gui = LibStub("AceGUI-3.0")
 local reg = LibStub("AceConfigRegistry-3.0")
 
-local MAJOR, MINOR = "AceConfigDialog-3.0", 85
+local MAJOR, MINOR = "AceConfigDialog-3.0", 86
 local AceConfigDialog, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceConfigDialog then return end
@@ -147,6 +147,7 @@ local stringIsLiteral = {
 	width = true,
 	image = true,
 	fontSize = true,
+	tooltipHyperlink = true
 }
 
 --Is Never a function or method
@@ -501,6 +502,14 @@ local function OptionOnMouseOver(widget, event)
 	local tooltip = AceConfigDialog.tooltip
 
 	tooltip:SetOwner(widget.frame, "ANCHOR_TOPRIGHT")
+
+	local tooltipHyperlink = GetOptionsMemberValue("tooltipHyperlink", opt, options, path, appName)
+	if tooltipHyperlink then
+		tooltip:SetHyperlink(tooltipHyperlink)
+		tooltip:Show()
+		return
+	end
+
 	local name = GetOptionsMemberValue("name", opt, options, path, appName)
 	local desc = GetOptionsMemberValue("desc", opt, options, path, appName)
 	local usage = GetOptionsMemberValue("usage", opt, options, path, appName)

--- a/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
@@ -8,10 +8,10 @@
 -- :IterateOptionsTables() (and :GetOptionsTable() if only given one argument) return a function reference that the requesting config handling addon must call with valid "uiType", "uiName".
 -- @class file
 -- @name AceConfigRegistry-3.0
--- @release $Id: AceConfigRegistry-3.0.lua 1207 2019-06-23 12:08:33Z nevcairiel $
+-- @release $Id: AceConfigRegistry-3.0.lua 1296 2022-11-04 18:50:10Z nevcairiel $
 local CallbackHandler = LibStub("CallbackHandler-1.0")
 
-local MAJOR, MINOR = "AceConfigRegistry-3.0", 20
+local MAJOR, MINOR = "AceConfigRegistry-3.0", 21
 local AceConfigRegistry = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not AceConfigRegistry then return end
@@ -83,6 +83,7 @@ local basekeys={
 		dialogHidden=optmethodbool,
 		dropdownHidden=optmethodbool,
 	cmdHidden=optmethodbool,
+	tooltipHyperlink=optstringfunc,
 	icon=optstringnumberfunc,
 	iconCoords=optmethodtable,
 	handler=opttable,

--- a/Libs/AceDB-3.0/AceDB-3.0.lua
+++ b/Libs/AceDB-3.0/AceDB-3.0.lua
@@ -40,8 +40,8 @@
 -- end
 -- @class file
 -- @name AceDB-3.0.lua
--- @release $Id: AceDB-3.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $
-local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 27
+-- @release $Id: AceDB-3.0.lua 1306 2023-06-23 14:55:09Z nevcairiel $
+local ACEDB_MAJOR, ACEDB_MINOR = "AceDB-3.0", 28
 local AceDB = LibStub:NewLibrary(ACEDB_MAJOR, ACEDB_MINOR)
 
 if not AceDB then return end -- No upgrade needed
@@ -260,7 +260,7 @@ local factionrealmKey = factionKey .. " - " .. realmKey
 local localeKey = GetLocale():lower()
 
 local regionTable = { "US", "KR", "EU", "TW", "CN" }
-local regionKey = regionTable[GetCurrentRegion()]
+local regionKey = regionTable[GetCurrentRegion()] or GetCurrentRegionName() or "TR"
 local factionrealmregionKey = factionrealmKey .. " - " .. regionKey
 
 -- Actual database initialization function

--- a/Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
+++ b/Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
@@ -1,5 +1,5 @@
---[[ $Id: CallbackHandler-1.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $ ]]
-local MAJOR, MINOR = "CallbackHandler-1.0", 7
+--[[ $Id: CallbackHandler-1.0.lua 1298 2022-12-12 15:10:10Z nevcairiel $ ]]
+local MAJOR, MINOR = "CallbackHandler-1.0", 8
 local CallbackHandler = LibStub:NewLibrary(MAJOR, MINOR)
 
 if not CallbackHandler then return end -- No upgrade needed
@@ -7,21 +7,16 @@ if not CallbackHandler then return end -- No upgrade needed
 local meta = {__index = function(tbl, key) tbl[key] = {} return tbl[key] end}
 
 -- Lua APIs
-local error = error
+local securecallfunction, error = securecallfunction, error
 local setmetatable, rawget = setmetatable, rawget
 local next, select, pairs, type, tostring = next, select, pairs, type, tostring
 
-local xpcall = xpcall
-
-local function errorhandler(err)
-	return geterrorhandler()(err)
-end
 
 local function Dispatch(handlers, ...)
 	local index, method = next(handlers)
 	if not method then return end
 	repeat
-		xpcall(method, errorhandler, ...)
+		securecallfunction(method, ...)
 		index, method = next(handlers, index)
 	until not method
 end

--- a/Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
+++ b/Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua
@@ -1,4 +1,4 @@
-
+--@curseforge-project-slug: libdbicon-1-0@
 -----------------------------------------------------------------------
 -- LibDBIcon-1.0
 --
@@ -6,7 +6,7 @@
 --
 
 local DBICON10 = "LibDBIcon-1.0"
-local DBICON10_MINOR = 43 -- Bump on changes
+local DBICON10_MINOR = 52 -- Bump on changes
 if not LibStub then error(DBICON10 .. " requires LibStub.") end
 local ldb = LibStub("LibDataBroker-1.1", true)
 if not ldb then error(DBICON10 .. " requires LibDataBroker-1.1.") end
@@ -16,10 +16,9 @@ if not lib then return end
 lib.objects = lib.objects or {}
 lib.callbackRegistered = lib.callbackRegistered or nil
 lib.callbacks = lib.callbacks or LibStub("CallbackHandler-1.0"):New(lib)
-lib.notCreated = lib.notCreated or {}
 lib.radius = lib.radius or 5
+local next, Minimap, CreateFrame, AddonCompartmentFrame = next, Minimap, CreateFrame, AddonCompartmentFrame
 lib.tooltip = lib.tooltip or CreateFrame("GameTooltip", "LibDBIconTooltip", UIParent, "GameTooltipTemplate")
-local next, Minimap = next, Minimap
 local isDraggingButton = false
 
 function lib:IconCallback(event, name, key, value)
@@ -92,6 +91,33 @@ local function onLeave(self)
 	local obj = self.dataObject
 	if obj.OnLeave then
 		obj.OnLeave(self)
+	end
+end
+
+local function onEnterCompartment(self)
+	local buttonName = self.value
+	local object = lib.objects[buttonName]
+	if object and object.dataObject then
+		if object.dataObject.OnTooltipShow then
+			lib.tooltip:SetOwner(self, "ANCHOR_NONE")
+			lib.tooltip:SetPoint(getAnchors(self))
+			object.dataObject.OnTooltipShow(lib.tooltip)
+			lib.tooltip:Show()
+		elseif object.dataObject.OnEnter then
+			object.dataObject.OnEnter(self)
+		end
+	end
+end
+
+local function onLeaveCompartment(self)
+	lib.tooltip:Hide()
+
+	local buttonName = self.value
+	local object = lib.objects[buttonName]
+	if object and object.dataObject then
+		if object.dataObject.OnLeave then
+			object.dataObject.OnLeave(self)
+		end
 	end
 end
 
@@ -213,36 +239,54 @@ local function updateCoord(self)
 	self:SetTexCoord(coords[1] + deltaX, coords[2] - deltaX, coords[3] + deltaY, coords[4] - deltaY)
 end
 
-local function createButton(name, object, db)
+local function createButton(name, object, db, customCompartmentIcon)
 	local button = CreateFrame("Button", "LibDBIcon10_"..name, Minimap)
 	button.dataObject = object
 	button.db = db
 	button:SetFrameStrata("MEDIUM")
-	button:SetSize(31, 31)
+	button:SetFixedFrameStrata(true)
 	button:SetFrameLevel(8)
+	button:SetFixedFrameLevel(true)
+	button:SetSize(31, 31)
 	button:RegisterForClicks("anyUp")
 	button:RegisterForDrag("LeftButton")
 	button:SetHighlightTexture(136477) --"Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight"
-	local overlay = button:CreateTexture(nil, "OVERLAY")
-	overlay:SetSize(53, 53)
-	overlay:SetTexture(136430) --"Interface\\Minimap\\MiniMap-TrackingBorder"
-	overlay:SetPoint("TOPLEFT")
-	local background = button:CreateTexture(nil, "BACKGROUND")
-	background:SetSize(20, 20)
-	background:SetTexture(136467) --"Interface\\Minimap\\UI-Minimap-Background"
-	background:SetPoint("TOPLEFT", 7, -5)
-	local icon = button:CreateTexture(nil, "ARTWORK")
-	icon:SetSize(17, 17)
-	icon:SetTexture(object.icon)
-	icon:SetPoint("TOPLEFT", 7, -6)
-	button.icon = icon
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then
+		local overlay = button:CreateTexture(nil, "OVERLAY")
+		overlay:SetSize(50, 50)
+		overlay:SetTexture(136430) --"Interface\\Minimap\\MiniMap-TrackingBorder"
+		overlay:SetPoint("TOPLEFT", button, "TOPLEFT")
+		local background = button:CreateTexture(nil, "BACKGROUND")
+		background:SetSize(24, 24)
+		background:SetTexture(136467) --"Interface\\Minimap\\UI-Minimap-Background"
+		background:SetPoint("CENTER", button, "CENTER")
+		local icon = button:CreateTexture(nil, "ARTWORK")
+		icon:SetSize(18, 18)
+		icon:SetTexture(object.icon)
+		icon:SetPoint("CENTER", button, "CENTER")
+		button.icon = icon
+	else
+		local overlay = button:CreateTexture(nil, "OVERLAY")
+		overlay:SetSize(53, 53)
+		overlay:SetTexture(136430) --"Interface\\Minimap\\MiniMap-TrackingBorder"
+		overlay:SetPoint("TOPLEFT")
+		local background = button:CreateTexture(nil, "BACKGROUND")
+		background:SetSize(20, 20)
+		background:SetTexture(136467) --"Interface\\Minimap\\UI-Minimap-Background"
+		background:SetPoint("TOPLEFT", 7, -5)
+		local icon = button:CreateTexture(nil, "ARTWORK")
+		icon:SetSize(17, 17)
+		icon:SetTexture(object.icon)
+		icon:SetPoint("TOPLEFT", 7, -6)
+		button.icon = icon
+	end
+
 	button.isMouseDown = false
+	local r, g, b = button.icon:GetVertexColor()
+	button.icon:SetVertexColor(object.iconR or r, object.iconG or g, object.iconB or b)
 
-	local r, g, b = icon:GetVertexColor()
-	icon:SetVertexColor(object.iconR or r, object.iconG or g, object.iconB or b)
-
-	icon.UpdateCoord = updateCoord
-	icon:UpdateCoord()
+	button.icon.UpdateCoord = updateCoord
+	button.icon:UpdateCoord()
 
 	button:SetScript("OnEnter", onEnter)
 	button:SetScript("OnLeave", onLeave)
@@ -273,23 +317,18 @@ local function createButton(name, object, db)
 			button:Hide()
 		end
 	end
-	lib.callbacks:Fire("LibDBIcon_IconCreated", button, name) -- Fire 'Icon Created' callback
-end
 
--- We could use a metatable.__index on lib.objects, but then we'd create
--- the icons when checking things like :IsRegistered, which is not necessary.
-local function check(name)
-	if lib.notCreated[name] then
-		createButton(name, lib.notCreated[name][1], lib.notCreated[name][2])
-		lib.notCreated[name] = nil
+	if db and db.showInCompartment then
+		lib:AddButtonToCompartment(name, customCompartmentIcon)
 	end
+	lib.callbacks:Fire("LibDBIcon_IconCreated", button, name) -- Fire 'Icon Created' callback
 end
 
 -- Wait a bit with the initial positioning to let any GetMinimapShape addons
 -- load up.
 if not lib.loggedIn then
-	local f = CreateFrame("Frame")
-	f:SetScript("OnEvent", function(f)
+	local frame = CreateFrame("Frame")
+	frame:SetScript("OnEvent", function(self)
 		for _, button in next, lib.objects do
 			updatePosition(button, button.db and button.db.minimapPos)
 			if not button.db or not button.db.hide then
@@ -299,90 +338,9 @@ if not lib.loggedIn then
 			end
 		end
 		lib.loggedIn = true
-		f:SetScript("OnEvent", nil)
+		self:SetScript("OnEvent", nil)
 	end)
-	f:RegisterEvent("PLAYER_LOGIN")
-end
-
-local function getDatabase(name)
-	return lib.notCreated[name] and lib.notCreated[name][2] or lib.objects[name].db
-end
-
-function lib:Register(name, object, db)
-	if not object.icon then error("Can't register LDB objects without icons set!") end
-	if lib.objects[name] or lib.notCreated[name] then error(DBICON10.. ": Object '".. name .."' is already registered.") end
-	if not db or not db.hide then
-		createButton(name, object, db)
-	else
-		lib.notCreated[name] = {object, db}
-	end
-end
-
-function lib:Lock(name)
-	if not lib:IsRegistered(name) then return end
-	if lib.objects[name] then
-		lib.objects[name]:SetScript("OnDragStart", nil)
-		lib.objects[name]:SetScript("OnDragStop", nil)
-	end
-	local db = getDatabase(name)
-	if db then
-		db.lock = true
-	end
-end
-
-function lib:Unlock(name)
-	if not lib:IsRegistered(name) then return end
-	if lib.objects[name] then
-		lib.objects[name]:SetScript("OnDragStart", onDragStart)
-		lib.objects[name]:SetScript("OnDragStop", onDragStop)
-	end
-	local db = getDatabase(name)
-	if db then
-		db.lock = nil
-	end
-end
-
-function lib:Hide(name)
-	if not lib.objects[name] then return end
-	lib.objects[name]:Hide()
-end
-
-function lib:Show(name)
-	check(name)
-	local button = lib.objects[name]
-	if button then
-		button:Show()
-		updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
-	end
-end
-
-function lib:IsRegistered(name)
-	return (lib.objects[name] or lib.notCreated[name]) and true or false
-end
-
-function lib:Refresh(name, db)
-	check(name)
-	local button = lib.objects[name]
-	if db then
-		button.db = db
-	end
-	updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
-	if not button.db or not button.db.hide then
-		button:Show()
-	else
-		button:Hide()
-	end
-	if not button.db or not button.db.lock then
-		button:SetScript("OnDragStart", onDragStart)
-		button:SetScript("OnDragStop", onDragStop)
-	else
-		button:SetScript("OnDragStart", nil)
-		button:SetScript("OnDragStop", nil)
-	end
-end
-
-function lib:GetMinimapButton(name)
-	return lib.objects[name]
+	frame:RegisterEvent("PLAYER_LOGIN")
 end
 
 do
@@ -405,21 +363,98 @@ do
 	end
 	Minimap:HookScript("OnEnter", OnMinimapEnter)
 	Minimap:HookScript("OnLeave", OnMinimapLeave)
+end
 
-	function lib:ShowOnEnter(name, value)
-		local button = lib.objects[name]
-		if button then
-			if value then
-				button.showOnMouseover = true
-				button.fadeOut:Stop()
-				button:SetAlpha(0)
-			else
-				button.showOnMouseover = false
-				button.fadeOut:Stop()
-				button:SetAlpha(1)
-			end
+--------------------------------------------------------------------------------
+-- Button API
+--
+
+function lib:Register(name, object, db, customCompartmentIcon)
+	if not object.icon then error("Can't register LDB objects without icons set!") end
+	if lib:GetMinimapButton(name) then error(DBICON10.. ": Object '".. name .."' is already registered.") end
+	createButton(name, object, db, customCompartmentIcon)
+end
+
+function lib:Lock(name)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		button:SetScript("OnDragStart", nil)
+		button:SetScript("OnDragStop", nil)
+		if button.db then
+			button.db.lock = true
 		end
 	end
+end
+
+function lib:Unlock(name)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		button:SetScript("OnDragStart", onDragStart)
+		button:SetScript("OnDragStop", onDragStop)
+		if button.db then
+			button.db.lock = nil
+		end
+	end
+end
+
+function lib:Hide(name)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		button:Hide()
+	end
+end
+
+function lib:Show(name)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		button:Show()
+		updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
+	end
+end
+
+function lib:IsRegistered(name)
+	return lib.objects[name] and true or false
+end
+
+function lib:Refresh(name, db)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		if db then
+			button.db = db
+		end
+		updatePosition(button, button.db and button.db.minimapPos or button.minimapPos)
+		if not button.db or not button.db.hide then
+			button:Show()
+		else
+			button:Hide()
+		end
+		if not button.db or not button.db.lock then
+			button:SetScript("OnDragStart", onDragStart)
+			button:SetScript("OnDragStop", onDragStop)
+		else
+			button:SetScript("OnDragStart", nil)
+			button:SetScript("OnDragStop", nil)
+		end
+	end
+end
+
+function lib:ShowOnEnter(name, value)
+	local button = lib:GetMinimapButton(name)
+	if button then
+		if value then
+			button.showOnMouseover = true
+			button.fadeOut:Stop()
+			button:SetAlpha(0)
+		else
+			button.showOnMouseover = false
+			button.fadeOut:Stop()
+			button:SetAlpha(1)
+		end
+	end
+end
+
+function lib:GetMinimapButton(name)
+	return lib.objects[name]
 end
 
 function lib:GetButtonList()
@@ -443,9 +478,69 @@ function lib:SetButtonToPosition(button, position)
 	updatePosition(lib.objects[button] or button, position)
 end
 
--- Upgrade!
+--------------------------------------------------------------------------------
+-- Addon Compartment API
+--
+
+function lib:IsButtonCompartmentAvailable()
+	if AddonCompartmentFrame then
+		return true
+	end
+end
+
+function lib:IsButtonInCompartment(buttonName)
+	local object = lib.objects[buttonName]
+	if object and object.db and object.db.showInCompartment then
+		return true
+	end
+	return false
+end
+
+function lib:AddButtonToCompartment(buttonName, customIcon)
+	local object = lib.objects[buttonName]
+	if object and not object.compartmentData and AddonCompartmentFrame then
+		if object.db then
+			object.db.showInCompartment = true
+		end
+		object.compartmentData = {
+			text = buttonName,
+			icon = customIcon or object.dataObject.icon,
+			notCheckable = true,
+			registerForAnyClick = true,
+			func = function(frame, _, _, _, clickType)
+				object.dataObject.OnClick(frame, clickType)
+			end,
+			funcOnEnter = onEnterCompartment,
+			funcOnLeave = onLeaveCompartment,
+		}
+		AddonCompartmentFrame:RegisterAddon(object.compartmentData)
+	end
+end
+
+function lib:RemoveButtonFromCompartment(buttonName)
+	local object = lib.objects[buttonName]
+	if object and object.compartmentData then
+		for i = 1, #AddonCompartmentFrame.registeredAddons do
+			local entry = AddonCompartmentFrame.registeredAddons[i]
+			if entry == object.compartmentData then
+				object.compartmentData = nil
+				if object.db then
+					object.db.showInCompartment = nil
+				end
+				table.remove(AddonCompartmentFrame.registeredAddons, i)
+				AddonCompartmentFrame:UpdateDisplay()
+				return
+			end
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+-- Upgrades
+--
+
 for name, button in next, lib.objects do
-	local db = getDatabase(name)
+	local db = button.db
 	if not db or not db.lock then
 		button:SetScript("OnDragStart", onDragStart)
 		button:SetScript("OnDragStop", onDragStop)
@@ -466,4 +561,11 @@ for name, button in next, lib.objects do
 		animOut:SetStartDelay(1)
 		button.fadeOut:SetToFinalAlpha(true)
 	end
+end
+lib:SetButtonRadius(lib.radius) -- Upgrade to 40
+if lib.notCreated then -- Upgrade to 50
+	for name in next, lib.notCreated do
+		createButton(name, lib.notCreated[name][1], lib.notCreated[name][2])
+	end
+	lib.notCreated = nil
 end

--- a/Libs/tdGUI/View/ListView.lua
+++ b/Libs/tdGUI/View/ListView.lua
@@ -13,11 +13,11 @@ function ListView:Constructor(parent)
     self.update = self.Refresh
     self:SetScript('OnSizeChanged', self.OnSizeChanged)
 
-    self.scrollBar:ClearAllPoints()
-    self.scrollBar:SetPoint('TOPRIGHT', 0, -18)
-    self.scrollBar:SetPoint('BOTTOMRIGHT', 0, 18)
+    self.ScrollBar:ClearAllPoints()
+    self.ScrollBar:SetPoint('TOPRIGHT', 0, -18)
+    self.ScrollBar:SetPoint('BOTTOMRIGHT', 0, 18)
 
-    self.scrollBar.doNotHide = true
+    self.ScrollBar.doNotHide = true
 
     self:SetSelectMode('NONE')
     self:ClearAllPoints()
@@ -57,14 +57,14 @@ function ListView:UpdateScroll()
     self.buttonHeight = buttonHeight
 
     self:GetScrollChild():SetSize(self:GetWidth(), maxHeight)
-	self:SetVerticalScroll(0)
-	self:UpdateScrollChildRect()
+    self:SetVerticalScroll(0)
+    self:UpdateScrollChildRect()
 
-    self.scrollBar:SetMinMaxValues(0, maxHeight)
-    self.scrollBar.buttonHeight = buttonHeight
-    self.scrollBar:SetValueStep(buttonHeight)
-    self.scrollBar:SetStepsPerPage(maxCount - 2)
-    self.scrollBar:SetValue(0)
+    self.ScrollBar:SetMinMaxValues(0, maxHeight)
+    self.ScrollBar.buttonHeight = buttonHeight
+    self.ScrollBar:SetValueStep(buttonHeight)
+    self.ScrollBar:SetStepsPerPage(maxCount - 2)
+    self.ScrollBar:SetValue(0)
 end
 
 function ListView:UpdateItems()


### PR DESCRIPTION
While testing on the 10.2 PTR. I encounter a few errors. 

First was AceDB, which was fixed a few months ago.

Second one is a little more odd. On Live, the parentKey `scrollBar` from `HybridScrollBarBackgroundTemplate` isn't over written with the parentKey `ScrollBar` from `BasicHybridScrollFrameTemplate`. They both appear to exist. But on PTR the key `scrollBar` isnt there, causing an error. Using `ScrollBar` works on live, and stops errors on PTR. 

I'm guessing that blizzard changed something with their template engine. As that template/file hasn't changed in a few expansions.

See: https://github.com/Gethe/wow-ui-source/blame/ptr2/Interface/SharedXML/HybridScrollFrame.xml#L194

I also updated a few other Libs while I was in the folder ;) 