### PR TITLE
Rematch5 compatibility (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Script editor auto completion now correctly offers `weather`, `weather.duration` and `trap` and no longer offers the wrong `self.weather`.
 - If the same ability is available multiple times, the instance with the shortest cooldown **and** lockdown is chosen now.
 - Correctly import scripts with spaces in their name.
+- No longer break when Rematch is not loaded and script browser or the share functionality is used.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## v1.9
 
+### Compatibility with Rematch 5
+
+Together with patch 10.2 Gello releases Rematch 5, which is a major change both under the hood and in the user interface. To properly integrate again we had to make changes to this addon as well. To allow for users updating with a delay, this addon is compatible with Rematch 4 and Rematch 5 at the same time.
+
+Rematch offers `/rematch reset everything` in case anything goes wrong in the update process, which this addon hooks to also save your matching scripts and tries to restore them in a reset case as well. Hopefully, there is no reason to use it though.
+
+One small change you will encounter is that the "script button" in the team list is now non-interactive: It only shows whether there is a script or not, but you can't click it anymore to edit the script. The option to create and edit the script from the right click menu is still there, of course.
+
 ### New features
 
 - Added condition `hp.diff` and `hpp.diff` allowing to compare own and enemy pet HP. `hp.diff = self.hp - enemy.hp` and `hpp.diff = self.hpp - enemy.hpp`. This can be used as condition for abilities that do more than one effect but use a condition after a subset of those effects (i.e. "does double damage if health difference is bigger than x after first damage effect").
@@ -9,6 +17,7 @@
 ### Breaking Changes
 
 - Conditions that require to specify a pet now correctly check that. `[ hp > 1 ]` was never valid and thus never true, but did not provoke an error to hint users to change it to `[ self.hp > 1 ]`. This change only breaks scripts that are currently silently broken already.
+- Plugins that use extra data in import/export strings are now forced to import the data without user choice. The plugin API has changed from `Plugin:OnImport(extra)` to `Plugin:OnImport(script, extra)` to allow for mapping between script and extra data.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add missing check that conditions with comparisons compare against numbers.
 - Script editor auto completion now correctly offers `weather`, `weather.duration` and `trap` and no longer offers the wrong `self.weather`.
 - If the same ability is available multiple times, the instance with the shortest cooldown **and** lockdown is chosen now.
+- Correctly import scripts with spaces in their name.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Script editor auto completion now correctly offers `weather`, `weather.duration` and `trap` and no longer offers the wrong `self.weather`.
 - If the same ability is available multiple times, the instance with the shortest cooldown **and** lockdown is chosen now.
 - Correctly import scripts with spaces in their name.
+- Correctly refresh the script manager if a script's name or code changes.
 - No longer break when Rematch is not loaded and script browser or the share functionality is used.
 
 ### Other

--- a/Core/Addon.lua
+++ b/Core/Addon.lua
@@ -18,6 +18,8 @@ _G.PetBattleScripts = Addon
 -- TODO: remove before merge, add to curseforge
 ns.L['SELECTOR_REMATCH_CANT_FORMAT_TOOLTIP_REMATCH_NOT_LOADED'] = "Can't show information: Rematch addon not loaded."
 ns.L['SHARE_IMPORT_PLUGIN_NOT_ENABLED'] = "Can't import: Plugin is not enabled."
+ns.L['SHARE_IMPORT_LABEL_HAS_EXTRA'] = "This import string will import extra data in addition to just the script, depending on the script plugin. Usually, this is information about the corresponding team."
+ns.L['SHARE_IMPORT_LABEL_EXTRA'] = nil
 
 function Addon:OnInitialize()
     local defaults = {

--- a/Core/Addon.lua
+++ b/Core/Addon.lua
@@ -15,6 +15,10 @@ ns.ICON  = [[Interface\Icons\Icon_petfamily_dragon]]
 
 _G.PetBattleScripts = Addon
 
+-- TODO: remove before merge, add to curseforge
+ns.L['SELECTOR_REMATCH_CANT_FORMAT_TOOLTIP_REMATCH_NOT_LOADED'] = "Can't show information: Rematch addon not loaded."
+ns.L['SHARE_IMPORT_PLUGIN_NOT_ENABLED'] = "Can't import: Plugin is not enabled."
+
 function Addon:OnInitialize()
     local defaults = {
         global = {

--- a/Core/Addon.lua
+++ b/Core/Addon.lua
@@ -20,6 +20,8 @@ ns.L['SELECTOR_REMATCH_CANT_FORMAT_TOOLTIP_REMATCH_NOT_LOADED'] = "Can't show in
 ns.L['SHARE_IMPORT_PLUGIN_NOT_ENABLED'] = "Can't import: Plugin is not enabled."
 ns.L['SHARE_IMPORT_LABEL_HAS_EXTRA'] = "This import string will import extra data in addition to just the script, depending on the script plugin. Usually, this is information about the corresponding team."
 ns.L['SHARE_IMPORT_LABEL_EXTRA'] = nil
+ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_NOTE = 'Updated from Rematch 4 to Rematch 5. Please check whether your scripts are still correctly linked to teams.\nIf the upgrade failed, restore a backup of wow/WTF/Account/<your account>/SavedVariables/tdBattlePetScript.lua, or open it and search for "Rematch" and remove or replace with "Rematch5", then search for "Rematch4" and replace it with "Rematch". Then downgrade back to Rematch 4 and report a bug on https://github.com/axc450/pbs/issues/new, attaching your saved variables file for Rematch and this addon.'
+ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_ORPHAN = 'Found script named "%s" which is linked to the non-existent Rematch team id "%s".\nThis can indicate an issue during updating the database, or a previous corruption. If this error has happened to a lot of teams, please report it as a bug. Otherwise, just remove orphaned teams via the Script Browser and re-add them to the correct teams.'
 
 function Addon:OnInitialize()
     local defaults = {

--- a/Core/Core.xml
+++ b/Core/Core.xml
@@ -13,4 +13,5 @@
     <Script file="Director.lua" />
     <Script file="Script.lua" />
     <Script file="Share.lua" />
+    <Script file="Version.lua" />
 </Ui>

--- a/Core/Manager/PluginManager.lua
+++ b/Core/Manager/PluginManager.lua
@@ -18,7 +18,6 @@ function PluginManager:OnInitialize()
     self.moduleWatings = {}
     self.moduleEnableQueue = {}
     self.pluginsOrdered = {}
-    self.rematchInstalled = false
     self.db = Addon.db
 end
 
@@ -27,7 +26,6 @@ function PluginManager:OnEnable()
     self:InitOrders()
     self:UpdatePlugins()
     self:RebuildPluginOrders()
-    self:CheckRematch()
 
     C_Timer.After(0, function()
         self:LoadPlugins()
@@ -111,20 +109,6 @@ function PluginManager:UpdatePlugins()
             }
         end)
     end
-end
-
-function PluginManager:CheckRematch()
-    for i = 1, GetNumAddOns() do
-        local name = GetAddOnInfo(i)
-        if (name == "Rematch") then
-            self.rematchInstalled = true
-            return
-        end
-    end
-end
-
-function PluginManager:RematchInstalled()
-    return self.rematchInstalled
 end
 
 function PluginManager:RebuildPluginOrders()

--- a/Core/Manager/ScriptManager.lua
+++ b/Core/Manager/ScriptManager.lua
@@ -31,6 +31,16 @@ function ScriptManager:RemoveScript(plugin, key)
     self:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
 end
 
+function ScriptManager:MoveScript(plugin, oldKey, newKey)
+    local script = db[plugin][oldKey]
+    db[plugin][oldKey] = nil
+    script = Addon:GetClass('Script'):New(script:GetDB(), script:GetPlugin(), newKey)
+    db[plugin][newKey] = script
+    self:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_REMOVED', plugin, oldKey)
+    self:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_ADDED', plugin, newKey, script)
+    self:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
+end
+
 function ScriptManager:IteratePluginScripts(plugin)
     return pairs(db[plugin])
 end

--- a/Core/Prototype/Plugin.lua
+++ b/Core/Prototype/Plugin.lua
@@ -29,7 +29,7 @@ function PluginPrototype:OnExport(key)
     return
 end
 
-function PluginPrototype:OnImport(data)
+function PluginPrototype:OnImport(script, extra)
     return
 end
 
@@ -45,6 +45,10 @@ end
 
 function PluginPrototype:AddScript(key, script)
     return ScriptManager:AddScript(self, key, script)
+end
+
+function PluginPrototype:MoveScript(oldKey, newKey)
+    return ScriptManager:MoveScript(self, oldKey, newKey)
 end
 
 function PluginPrototype:IterateScripts()

--- a/Core/Script.lua
+++ b/Core/Script.lua
@@ -25,6 +25,8 @@ end
 
 function Script:SetName(name)
     self.db.name = name
+    Addon:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_UPDATE')
+    Addon:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
 end
 
 function Script:GetCode()
@@ -39,6 +41,8 @@ function Script:SetCode(code)
 
     self.db.code = code
     self.script  = script
+    Addon:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_UPDATE')
+    Addon:SendMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
     return true
 end
 

--- a/Core/Version.lua
+++ b/Core/Version.lua
@@ -17,8 +17,8 @@ function Version:Constructor(major, minor, build, revision)
     self.revision = revision or 0
 end
 
-function Version:Current()
-    local version = GetAddOnMetadata('Rematch', 'Version')
+function Version:Current(addon)
+    local version = GetAddOnMetadata(addon, 'Version')
     if not version then
         return
     end

--- a/Core/Version.lua
+++ b/Core/Version.lua
@@ -18,6 +18,10 @@ function Version:Constructor(major, minor, build, revision)
 end
 
 function Version:Current(addon)
+    if GetAddOnEnableState(nil, addon) == 0 then
+        -- Disabled addon is considered not loaded.
+        return
+    end
     local version = GetAddOnMetadata(addon, 'Version')
     if not version then
         return

--- a/Libs/tdGUI/Widget/NotifyFrame.lua
+++ b/Libs/tdGUI/Widget/NotifyFrame.lua
@@ -258,7 +258,9 @@ function NotifyManager:Update()
     end)
     notify:SetOptions(opts)
     notify:FadeIn()
-	C_Timer.After(5, function() notify:FadeOut() end)
+    if opts.duration ~= -1 then
+        C_Timer.After(opts.duration or 5, function() notify:FadeOut() end)
+    end
 
     table.insert(ns.used, notify)
 
@@ -279,7 +281,7 @@ function GUI:Notify(opts)
             error(format([[bad argument opts.type to 'Notify' (ONCE|DAY)]]), 2)
         end
         if type(opts.storage) ~= 'table' then
-            error(format([[bad argument opts.storage to 'Notify' (string expected, got %s)]], type(opts.storage)), 2)
+            error(format([[bad argument opts.storage to 'Notify' (table expected, got %s)]], type(opts.storage)), 2)
         end
         if not opts.id then
             error(format([[bad argument opts.storage to 'Notify']]), 2)

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -7,6 +7,7 @@ Addon.lua
 local ns    = select(2, ...)
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
 local RematchPlugin = PetBattleScripts:NewPlugin('Rematch', 'AceEvent-3.0', 'AceHook-3.0', 'LibClass-2.0')
+local GUI   = LibStub('tdGUI-1.0')
 
 ns.RematchPlugin   = RematchPlugin
 
@@ -320,6 +321,14 @@ function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     end
     scriptsDB.Rematch4 = CopyTable(scriptsDB.Rematch)
 
+    C_Timer.After(0.9, function()
+        GUI:Notify{
+            text = format('%s\n|cff00ffff%s|r', ns.L.ADDON_NAME, ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_NOTE),
+            icon = ns.ICON,
+            duration = -1,
+        }
+    end)
+
     -- First we need a cache list of all of our scripts, so we can modify our scripts
     -- database without messing up the loops.
     local scriptList = {}
@@ -340,7 +349,13 @@ function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     -- Warn about scripts that are not linked to anything.
     for teamID, script in self:IterateScripts() do
         if not self.savedRematchTeams[teamID] then
-            print(ns.L.ADDON_NAME, 'Found an orphaned script:', 'name:', script:GetName(), 'key:', teamID)
+            C_Timer.After(0.9, function()
+                GUI:Notify{
+                    text = format('%s\n|cff00ffff%s|r', ns.L.ADDON_NAME, format(ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_ORPHAN, script:GetName(), teamID)),
+                    icon = ns.ICON,
+                    duration = -1,
+                }
+            end)
         end
     end
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -238,7 +238,11 @@ function RematchPlugin:OnTooltipFormatting(tip, key)
         for i=1,3 do
             local petID = GetTeamPets(saved, i)
             local petInfo = Rematch.petInfo:Fetch(petID)
-            tip:AddLine(format([[|T%s:20|t %s]],petInfo.icon,petInfo.name))
+            if petInfo.icon and petInfo.name then
+                tip:AddLine(format([[|T%s:20|t %s]],petInfo.icon,petInfo.name))
+            else
+                tip:AddLine(SEARCH_LOADING_TEXT)
+            end
         end
     end
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -109,11 +109,11 @@ function RematchPlugin:OnTooltipFormatting(tip, key)
     else
         tip:AddLine(format(L.SELECTOR_REMATCH_TEAM_FORMAT, Rematch:GetTeamTitle(key)), GREEN_FONT_COLOR:GetRGB())
 
-		for i=1,3 do
-			local petID = saved[i][1]
-			local petInfo = Rematch.petInfo:Fetch(petID)
-			tip:AddLine(format([[|T%s:20|t %s]],petInfo.icon,petInfo.name))
-		end
+        for i=1,3 do
+            local petID = saved[i][1]
+            local petInfo = Rematch.petInfo:Fetch(petID)
+            tip:AddLine(format([[|T%s:20|t %s]],petInfo.icon,petInfo.name))
+        end
     end
 end
 

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -18,9 +18,14 @@ function RematchPlugin:OnInitialize()
 end
 
 function RematchPlugin:OnEnable()
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     self.savedRematchTeams = RematchSaved
+end
 
     -- Team is deleted
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     local function FindMenuItem(menu, text)
         for i, v in ipairs(menu) do
             if v.text == text then
@@ -38,8 +43,10 @@ function RematchPlugin:OnEnable()
             return origAccept(...)
         end
     end, true)
+end
 
     -- Maintain sync between script name, and team name
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     local function rename(old, new)
         if not old then
             return
@@ -79,6 +86,7 @@ function RematchPlugin:OnEnable()
             rename(Rematch:GetSidelineContext('originalKey'), select(2, Rematch:GetSideline()))
         end)
     end)
+end
 
     -- UI
     self:SetupUI()
@@ -89,7 +97,11 @@ function RematchPlugin:OnDisable()
 end
 
 function RematchPlugin:GetCurrentKey()
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     return RematchSettings.loadedTeam
+end
 end
 
 function RematchPlugin:IterateKeys()
@@ -101,14 +113,22 @@ function RematchPlugin:IterateKeys()
 end
 
 function RematchPlugin:GetTitleByKey(key)
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     return Rematch:GetTeamTitle(key)
+end
 end
 
 function RematchPlugin:OnTooltipFormatting(tip, key)
+    local rematchVersion = ns.Version:Current('Rematch')
+
     local GetTeamName
     local GetTeamPets
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     GetTeamName = function(key) return Rematch:GetTeamTitle(key) end
     GetTeamPets = function(team, i) return team[i][1] end
+end
 
     local saved = self.savedRematchTeams[key]
     if not saved then
@@ -125,13 +145,21 @@ function RematchPlugin:OnTooltipFormatting(tip, key)
 end
 
 function RematchPlugin:OnExport(key)
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     if self.savedRematchTeams[key] then
         Rematch:SetSideline(key, self.savedRematchTeams[key])
         return Rematch:ConvertSidelineToString()
     end
 end
+end
 
 function RematchPlugin:OnImport(data)
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     Rematch:ShowImportDialog()
     RematchDialog.MultiLine.EditBox:SetText(data)
+end
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -17,6 +17,75 @@ function RematchPlugin:OnInitialize()
     self:SetPluginIcon([[Interface\AddOns\Rematch\Textures\icon]])
 end
 
+function RematchPlugin:OnEnable()
+    -- Team is deleted
+    local function FindMenuItem(menu, text)
+        for i, v in ipairs(menu) do
+            if v.text == text then
+                return v
+            end
+        end
+    end
+    local deleteItem = FindMenuItem(Rematch:GetMenu('TeamMenu'), DELETE)
+    self:RawHook(deleteItem, 'func', function(obj, key, ...)
+        self.hooks[deleteItem].func(obj, key, ...)
+
+        local origAccept = RematchDialog.acceptFunc
+        RematchDialog.acceptFunc = function(...)
+            self:RemoveScript(key)
+            return origAccept(...)
+        end
+    end, true)
+
+    -- Maintain sync between script name, and team name
+    local function rename(old, new)
+        if not old then
+            return
+        end
+        if old == new then
+            return
+        end
+        local script = self:GetScript(old)
+        if not script then
+            return
+        end
+
+        self:RemoveScript(old)
+        self:AddScript(new, script)
+    end
+
+    local function errorhandler(err)
+        return geterrorhandler()(err)
+    end
+
+    local function safecall(func, ...)
+        return xpcall(func, errorhandler, ...)
+    end
+
+    self:RawHook(Rematch, 'SaveAsAccept', function(...)
+        safecall(function()
+            local team, key = Rematch:GetSideline()
+            if not RematchSaved[key] or not Rematch:SidelinePetsDifferentThan(key) then
+                rename(Rematch:GetSidelineContext('originalKey'), key)
+            end
+        end)
+        return self.hooks[Rematch].SaveAsAccept(...)
+    end, true)
+
+    self:SecureHook(Rematch, 'OverwriteAccept', function()
+        safecall(function()
+            rename(Rematch:GetSidelineContext('originalKey'), select(2, Rematch:GetSideline()))
+        end)
+    end)
+
+    -- UI
+    self:SetupUI()
+end
+
+function RematchPlugin:OnDisable()
+    self:TeardownUI()
+end
+
 function RematchPlugin:GetCurrentKey()
     return RematchSettings.loadedTeam
 end
@@ -46,4 +115,16 @@ function RematchPlugin:OnTooltipFormatting(tip, key)
 			tip:AddLine(format([[|T%s:20|t %s]],petInfo.icon,petInfo.name))
 		end
     end
+end
+
+function RematchPlugin:OnExport(key)
+    if RematchSaved[key] then
+        Rematch:SetSideline(key, RematchSaved[key])
+        return Rematch:ConvertSidelineToString()
+    end
+end
+
+function RematchPlugin:OnImport(data)
+    Rematch:ShowImportDialog()
+    RematchDialog.MultiLine.EditBox:SetText(data)
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -314,6 +314,10 @@ end
 function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     -- Backup old scripts.
     local scriptsDB = PetBattleScripts.db.global.scripts
+    if scriptsDB.Rematch4 then
+        -- Already did an upgrade at some point, so don't do it again.
+        return
+    end
     scriptsDB.Rematch4 = CopyTable(scriptsDB.Rematch)
 
     -- First we need a cache list of all of our scripts, so we can modify our scripts

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -14,7 +14,11 @@ function RematchPlugin:OnInitialize()
     self:EnableWithAddon('Rematch')
     self:SetPluginTitle(L.SELECTOR_REMATCH_TITLE)
     self:SetPluginNotes(L.SELECTOR_REMATCH_NOTES)
-    self:SetPluginIcon([[Interface\AddOns\Rematch\Textures\icon]])
+
+    local rematchIcon = [[Interface\AddOns\Rematch\Textures\icon]]
+    local fallbackIcon = [[Interface\Icons\inv_misc_questionmark]]
+    local rematchExists = select(5, GetAddOnInfo('Rematch')) ~= 'MISSING'
+    self:SetPluginIcon(rematchExists and rematchIcon or fallbackIcon)
 end
 
 function RematchPlugin:OnEnable()
@@ -105,6 +109,12 @@ function RematchPlugin:GetCurrentKey()
 end
 
 function RematchPlugin:IterateKeys()
+    local rematchVersion = ns.Version:Current('Rematch')
+
+    if not rematchVersion then
+        return
+    end
+
     return coroutine.wrap(function()
         for key in pairs(self.savedRematchTeams) do
             coroutine.yield(key)
@@ -122,6 +132,11 @@ end
 
 function RematchPlugin:OnTooltipFormatting(tip, key)
     local rematchVersion = ns.Version:Current('Rematch')
+
+    if not rematchVersion then
+        tip:AddLine(L.SELECTOR_REMATCH_CANT_FORMAT_TOOLTIP_REMATCH_NOT_LOADED, RED_FONT_COLOR:GetRGB())
+        return
+    end
 
     local GetTeamName
     local GetTeamPets
@@ -147,6 +162,10 @@ end
 function RematchPlugin:OnExport(key)
     local rematchVersion = ns.Version:Current('Rematch')
 
+    if not rematchVersion then
+        return
+    end
+
     if rematchVersion < ns.Version:New(5, 0, 0, 0) then
         if self.savedRematchTeams[key] then
             Rematch:SetSideline(key, self.savedRematchTeams[key])
@@ -157,6 +176,10 @@ end
 
 function RematchPlugin:OnImport(data)
     local rematchVersion = ns.Version:Current('Rematch')
+
+    if not rematchVersion then
+        return
+    end
 
     if rematchVersion < ns.Version:New(5, 0, 0, 0) then
         Rematch:ShowImportDialog()

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -6,22 +6,22 @@ Addon.lua
 
 local ns    = select(2, ...)
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
-local Addon = PetBattleScripts:NewPlugin('Rematch', 'AceEvent-3.0', 'AceHook-3.0', 'LibClass-2.0')
+local RematchPlugin = PetBattleScripts:NewPlugin('Rematch', 'AceEvent-3.0', 'AceHook-3.0', 'LibClass-2.0')
 
-ns.Addon   = Addon
+ns.RematchPlugin   = RematchPlugin
 
-function Addon:OnInitialize()
+function RematchPlugin:OnInitialize()
     self:EnableWithAddon('Rematch')
     self:SetPluginTitle(L.SELECTOR_REMATCH_TITLE)
     self:SetPluginNotes(L.SELECTOR_REMATCH_NOTES)
     self:SetPluginIcon([[Interface\AddOns\Rematch\Textures\icon]])
 end
 
-function Addon:GetCurrentKey()
+function RematchPlugin:GetCurrentKey()
     return RematchSettings.loadedTeam
 end
 
-function Addon:IterateKeys()
+function RematchPlugin:IterateKeys()
     return coroutine.wrap(function()
         for key in pairs(RematchSaved) do
             coroutine.yield(key)
@@ -29,11 +29,11 @@ function Addon:IterateKeys()
     end)
 end
 
-function Addon:GetTitleByKey(key)
+function RematchPlugin:GetTitleByKey(key)
     return Rematch:GetTeamTitle(key)
 end
 
-function Addon:OnTooltipFormatting(tip, key)
+function RematchPlugin:OnTooltipFormatting(tip, key)
     local saved = RematchSaved[key]
     if not saved then
         tip:AddLine(L.SELECTOR_REMATCH_NO_TEAM_FOR_SCRIPT, RED_FONT_COLOR:GetRGB())

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -97,7 +97,13 @@ function RematchPlugin:OnEnable()
 end
 
 function RematchPlugin:OnDisable()
+    local rematchVersion = ns.Version:Current('Rematch')
+
     self:TeardownUI()
+
+    self:UnhookAll()
+
+    self.savedRematchTeams = nil
 end
 
 function RematchPlugin:GetCurrentKey()

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -326,8 +326,10 @@ function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     -- Second we can migrate scripts.
     for oldTeamID, script in pairs(scriptList) do
         local newTeamID = convertedTeams[oldTeamID]
-        if newTeamID then
+        local newTeam = Rematch.savedTeams[newTeamID]
+        if newTeamID and newTeam then
             self:MoveScript(oldTeamID, newTeamID)
+            self:GetScript(newTeamID):SetName(newTeam.name)
         end
     end
 

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -14,7 +14,7 @@ function Addon:OnInitialize()
     self:EnableWithAddon('Rematch')
     self:SetPluginTitle(L.SELECTOR_REMATCH_TITLE)
     self:SetPluginNotes(L.SELECTOR_REMATCH_NOTES)
-    self:SetPluginIcon([[Interface\Icons\Icon_petfamily_dragon]])
+    self:SetPluginIcon([[Interface\AddOns\Rematch\Textures\icon]])
 end
 
 function Addon:GetCurrentKey()

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -20,73 +20,73 @@ end
 function RematchPlugin:OnEnable()
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    self.savedRematchTeams = RematchSaved
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        self.savedRematchTeams = RematchSaved
+    end
 
     -- Team is deleted
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    local function FindMenuItem(menu, text)
-        for i, v in ipairs(menu) do
-            if v.text == text then
-                return v
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        local function FindMenuItem(menu, text)
+            for i, v in ipairs(menu) do
+                if v.text == text then
+                    return v
+                end
             end
         end
-    end
-    local deleteItem = FindMenuItem(Rematch:GetMenu('TeamMenu'), DELETE)
-    self:RawHook(deleteItem, 'func', function(obj, key, ...)
-        self.hooks[deleteItem].func(obj, key, ...)
+        local deleteItem = FindMenuItem(Rematch:GetMenu('TeamMenu'), DELETE)
+        self:RawHook(deleteItem, 'func', function(obj, key, ...)
+            self.hooks[deleteItem].func(obj, key, ...)
 
-        local origAccept = RematchDialog.acceptFunc
-        RematchDialog.acceptFunc = function(...)
-            self:RemoveScript(key)
-            return origAccept(...)
-        end
-    end, true)
-end
+            local origAccept = RematchDialog.acceptFunc
+            RematchDialog.acceptFunc = function(...)
+                self:RemoveScript(key)
+                return origAccept(...)
+            end
+        end, true)
+    end
 
     -- Maintain sync between script name, and team name
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    local function rename(old, new)
-        if not old then
-            return
-        end
-        if old == new then
-            return
-        end
-        local script = self:GetScript(old)
-        if not script then
-            return
-        end
-
-        self:RemoveScript(old)
-        self:AddScript(new, script)
-    end
-
-    local function errorhandler(err)
-        return geterrorhandler()(err)
-    end
-
-    local function safecall(func, ...)
-        return xpcall(func, errorhandler, ...)
-    end
-
-    self:RawHook(Rematch, 'SaveAsAccept', function(...)
-        safecall(function()
-            local team, key = Rematch:GetSideline()
-            if not self.savedRematchTeams[key] or not Rematch:SidelinePetsDifferentThan(key) then
-                rename(Rematch:GetSidelineContext('originalKey'), key)
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        local function rename(old, new)
+            if not old then
+                return
             end
-        end)
-        return self.hooks[Rematch].SaveAsAccept(...)
-    end, true)
+            if old == new then
+                return
+            end
+            local script = self:GetScript(old)
+            if not script then
+                return
+            end
 
-    self:SecureHook(Rematch, 'OverwriteAccept', function()
-        safecall(function()
-            rename(Rematch:GetSidelineContext('originalKey'), select(2, Rematch:GetSideline()))
+            self:RemoveScript(old)
+            self:AddScript(new, script)
+        end
+
+        local function errorhandler(err)
+            return geterrorhandler()(err)
+        end
+
+        local function safecall(func, ...)
+            return xpcall(func, errorhandler, ...)
+        end
+
+        self:RawHook(Rematch, 'SaveAsAccept', function(...)
+            safecall(function()
+                local team, key = Rematch:GetSideline()
+                if not self.savedRematchTeams[key] or not Rematch:SidelinePetsDifferentThan(key) then
+                    rename(Rematch:GetSidelineContext('originalKey'), key)
+                end
+            end)
+            return self.hooks[Rematch].SaveAsAccept(...)
+        end, true)
+
+        self:SecureHook(Rematch, 'OverwriteAccept', function()
+            safecall(function()
+                rename(Rematch:GetSidelineContext('originalKey'), select(2, Rematch:GetSideline()))
+            end)
         end)
-    end)
-end
+    end
 
     -- UI
     self:SetupUI()
@@ -99,9 +99,9 @@ end
 function RematchPlugin:GetCurrentKey()
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    return RematchSettings.loadedTeam
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        return RematchSettings.loadedTeam
+    end
 end
 
 function RematchPlugin:IterateKeys()
@@ -115,9 +115,9 @@ end
 function RematchPlugin:GetTitleByKey(key)
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    return Rematch:GetTeamTitle(key)
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        return Rematch:GetTeamTitle(key)
+    end
 end
 
 function RematchPlugin:OnTooltipFormatting(tip, key)
@@ -125,10 +125,10 @@ function RematchPlugin:OnTooltipFormatting(tip, key)
 
     local GetTeamName
     local GetTeamPets
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    GetTeamName = function(key) return Rematch:GetTeamTitle(key) end
-    GetTeamPets = function(team, i) return team[i][1] end
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        GetTeamName = function(key) return Rematch:GetTeamTitle(key) end
+        GetTeamPets = function(team, i) return team[i][1] end
+    end
 
     local saved = self.savedRematchTeams[key]
     if not saved then
@@ -147,19 +147,19 @@ end
 function RematchPlugin:OnExport(key)
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    if self.savedRematchTeams[key] then
-        Rematch:SetSideline(key, self.savedRematchTeams[key])
-        return Rematch:ConvertSidelineToString()
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        if self.savedRematchTeams[key] then
+            Rematch:SetSideline(key, self.savedRematchTeams[key])
+            return Rematch:ConvertSidelineToString()
+        end
     end
-end
 end
 
 function RematchPlugin:OnImport(data)
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    Rematch:ShowImportDialog()
-    RematchDialog.MultiLine.EditBox:SetText(data)
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        Rematch:ShowImportDialog()
+        RematchDialog.MultiLine.EditBox:SetText(data)
+    end
 end

--- a/Rematch/Rematch.xml
+++ b/Rematch/Rematch.xml
@@ -1,6 +1,5 @@
 <Ui xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
   <Script file="Addon.lua" />
-  <Script file="Version.lua" />
   <Script file="UI.lua" />
 </Ui>

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -18,6 +18,7 @@ local scriptMenuItem = {
     end
 }
 
+local scriptButtonIcon = 'Interface/AddOns/tdBattlePetScript/Rematch/Textures/ScriptIcon'
 -- Rematch4 only
 local scriptButtons = setmetatable({}, {
     __index = function(t, parent)
@@ -26,8 +27,8 @@ local scriptButtons = setmetatable({}, {
                 button:SetSize(18, 18)
             end
             button:SetPoint('CENTER')
-            button:SetNormalTexture("Interface/AddOns/tdBattlePetScript/Rematch/Textures/ScriptIcon")
-            button:SetPushedTexture("Interface/AddOns/tdBattlePetScript/Rematch/Textures/ScriptIcon")
+            button:SetNormalTexture(scriptButtonIcon)
+            button:SetPushedTexture(scriptButtonIcon)
             button:SetScript('OnClick', function(button)
                 RematchPlugin:OpenScriptEditor(button.key, Rematch:GetTeamTitle(button.key))
             end)

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -6,13 +6,13 @@ UI.lua
 
 local ns = select(2, ...)
 
-local Addon = ns.Addon
+local RematchPlugin = ns.RematchPlugin
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
 
 local teamMenu = {
     text = L.EDITOR_CREATE_SCRIPT,
     func = function(_, key, ...)
-        Addon:OpenScriptEditor(key, Rematch:GetTeamTitle(key))
+        RematchPlugin:OpenScriptEditor(key, Rematch:GetTeamTitle(key))
     end
 }
 
@@ -34,7 +34,7 @@ local scriptButtons = setmetatable({}, {
             button:SetNormalTexture("Interface/AddOns/tdBattlePetScript/Rematch/Textures/ScriptIcon")
             button:SetPushedTexture("Interface/AddOns/tdBattlePetScript/Rematch/Textures/ScriptIcon")
             button:SetScript('OnClick', function(button)
-                Addon:OpenScriptEditor(button.key, Rematch:GetTeamTitle(button.key))
+                RematchPlugin:OpenScriptEditor(button.key, Rematch:GetTeamTitle(button.key))
             end)
             button:SetScript('OnEnter', function(button)
                 GameTooltip:SetOwner(button, 'ANCHOR_RIGHT')
@@ -49,7 +49,7 @@ local scriptButtons = setmetatable({}, {
     end
 })
 
-function Addon:OnEnable()
+function RematchPlugin:OnEnable()
     local menu = Rematch:GetMenu('TeamMenu')
     local deleteItem = self:FindMenuItem(menu, DELETE)
 
@@ -234,11 +234,11 @@ function Addon:OnEnable()
     end)
 end
 
-function Addon:OnDisable()
+function RematchPlugin:OnDisable()
     tDeleteItem(Rematch:GetMenu('TeamMenu'), teamMenu)
 end
 
-function Addon:FindMenuItem(menu, text)
+function RematchPlugin:FindMenuItem(menu, text)
     for i, v in ipairs(menu) do
         if v.text == text then
             return v
@@ -246,14 +246,14 @@ function Addon:FindMenuItem(menu, text)
     end
 end
 
-function Addon:OnExport(key)
+function RematchPlugin:OnExport(key)
     if RematchSaved[key] then
         Rematch:SetSideline(key, RematchSaved[key])
         return Rematch:ConvertSidelineToString()
     end
 end
 
-function Addon:OnImport(data)
+function RematchPlugin:OnImport(data)
     Rematch:ShowImportDialog()
     RematchDialog.MultiLine.EditBox:SetText(data)
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -48,26 +48,26 @@ function RematchPlugin:SetupUI()
     local rematchVersion = ns.Version:Current('Rematch')
 
     -- Add menu to edit script
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
+    end
 
     -- When a script is added/removed, refresh the teams list.
     local updateFrames
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    updateFrames = function()
-        if RematchLoadedTeamPanel:IsVisible() then
-            RematchLoadedTeamPanel:Update()
-        end
-        if RematchTeamPanel:IsVisible() then
-            if RematchTeamPanel.UpdateList then
-                RematchTeamPanel:UpdateList()
-            elseif RematchTeamPanel.List then
-                RematchTeamPanel.List:Update()
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        updateFrames = function()
+            if RematchLoadedTeamPanel:IsVisible() then
+                RematchLoadedTeamPanel:Update()
+            end
+            if RematchTeamPanel:IsVisible() then
+                if RematchTeamPanel.UpdateList then
+                    RematchTeamPanel:UpdateList()
+                elseif RematchTeamPanel.List then
+                    RematchTeamPanel.List:Update()
+                end
             end
         end
     end
-end
     self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', updateFrames)
 
     -- Button to indicate a script exists
@@ -137,62 +137,62 @@ end
         end)
     end
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    local function move(button, add)
-        if not button:IsShown() then
-            return 0
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        local function move(button, add)
+            if not button:IsShown() then
+                return 0
+            end
+
+            local point, relative, relativePoint, x, y = button:GetPoint()
+            button:SetPoint(point, relative, relativePoint, x + 21, y)
+            return add
         end
 
-        local point, relative, relativePoint, x, y = button:GetPoint()
-        button:SetPoint(point, relative, relativePoint, x + 21, y)
-        return add
+        self:SecureHook(RematchLoadedTeamPanel, 'Update', function(panel)
+            local footnotes = panel.Footnotes
+            local script = scriptButtons[footnotes]
+
+            if self:GetScript(RematchSettings.loadedTeam) then
+                script.key = RematchSettings.loadedTeam
+                script:Show()
+                script:ClearAllPoints()
+                script:SetPoint('LEFT', 5, -0.5)
+
+                local fx = 5 + 21
+                fx = fx + move(footnotes.Preferences, 21)
+                fx = fx + move(footnotes.Notes, 21)
+                fx = fx + move(footnotes.WinRecord, footnotes.WinRecord:GetWidth())
+                fx = fx + move(footnotes.Maximize, 21)
+                fx = fx + move(footnotes.Close, 21)
+
+                local footnoteWidth = fx + 4
+                local panelWidth = panel.maxWidth or 280
+
+                footnotes:SetWidth(footnoteWidth)
+                footnotes:Show()
+                panel:SetWidth(panelWidth-footnoteWidth-3)
+            else
+                script:Hide()
+            end
+        end)
     end
 
-    self:SecureHook(RematchLoadedTeamPanel, 'Update', function(panel)
-        local footnotes = panel.Footnotes
-        local script = scriptButtons[footnotes]
-
-        if self:GetScript(RematchSettings.loadedTeam) then
-            script.key = RematchSettings.loadedTeam
-            script:Show()
-            script:ClearAllPoints()
-            script:SetPoint('LEFT', 5, -0.5)
-
-            local fx = 5 + 21
-            fx = fx + move(footnotes.Preferences, 21)
-            fx = fx + move(footnotes.Notes, 21)
-            fx = fx + move(footnotes.WinRecord, footnotes.WinRecord:GetWidth())
-            fx = fx + move(footnotes.Maximize, 21)
-            fx = fx + move(footnotes.Close, 21)
-
-            local footnoteWidth = fx + 4
-            local panelWidth = panel.maxWidth or 280
-
-            footnotes:SetWidth(footnoteWidth)
-            footnotes:Show()
-            panel:SetWidth(panelWidth-footnoteWidth-3)
-        else
-            script:Hide()
-        end
-    end)
-end
-
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    self:HookScript(RematchJournal, 'OnShow', function(self)
-        CollectionsJournal:SetAttribute('UIPanelLayout-width', 870)
-        UpdateUIPanelPositions()
-    end)
-    self:HookScript(RematchJournal, 'OnHide', function(self)
-        CollectionsJournal:SetAttribute('UIPanelLayout-width', 710)
-        UpdateUIPanelPositions()
-    end)
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        self:HookScript(RematchJournal, 'OnShow', function(self)
+            CollectionsJournal:SetAttribute('UIPanelLayout-width', 870)
+            UpdateUIPanelPositions()
+        end)
+        self:HookScript(RematchJournal, 'OnHide', function(self)
+            CollectionsJournal:SetAttribute('UIPanelLayout-width', 710)
+            UpdateUIPanelPositions()
+        end)
+    end
 end
 
 function RematchPlugin:TeardownUI()
     local rematchVersion = ns.Version:Current('Rematch')
 
-if rematchVersion < ns.Version:New(5, 0, 0, 0) then
-    tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
-end
+    if rematchVersion < ns.Version:New(5, 0, 0, 0) then
+        tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
+    end
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -10,7 +10,9 @@ local RematchPlugin = ns.RematchPlugin
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
 
 local scriptMenuItem = {
-    text = L.EDITOR_CREATE_SCRIPT,
+    text = function(_, key, ...)
+        return RematchPlugin:GetScript(key) and L.EDITOR_EDIT_SCRIPT or L.EDITOR_CREATE_SCRIPT
+    end,
     func = function(_, key, ...)
         RematchPlugin:OpenScriptEditor(key, Rematch:GetTeamTitle(key))
     end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -22,7 +22,8 @@ local scriptButtonIcon = 'Interface/AddOns/tdBattlePetScript/Rematch/Textures/Sc
 -- Rematch4 only
 local scriptButtons = setmetatable({}, {
     __index = function(t, parent)
-        local button = CreateFrame('Button', nil, parent, 'RematchFootnoteButtonTemplate') do
+        local button = CreateFrame('Button', nil, parent, 'RematchFootnoteButtonTemplate')
+        do
             if parent.slim then
                 button:SetSize(18, 18)
             end
@@ -195,5 +196,19 @@ function RematchPlugin:TeardownUI()
 
     if rematchVersion < ns.Version:New(5, 0, 0, 0) then
         tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
+        for _, frame in pairs(scriptButtons) do
+            frame:ClearAllPoints()
+            frame:Hide()
+        end
+        if RematchLoadedTeamPanel:IsVisible() then
+            RematchLoadedTeamPanel:Update()
+        end
+        if RematchTeamPanel:IsVisible() then
+            if RematchTeamPanel.UpdateList then
+                RematchTeamPanel:UpdateList()
+            elseif RematchTeamPanel.List then
+                RematchTeamPanel.List:Update()
+            end
+        end
     end
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -189,6 +189,8 @@ function RematchPlugin:SetupUI()
             UpdateUIPanelPositions()
         end)
     end
+
+    updateFrames()
 end
 
 function RematchPlugin:TeardownUI()

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -59,15 +59,15 @@ function RematchPlugin:SetupUI()
     end
 
     -- When a script is added/removed, refresh the teams list.
-    local updateFrames
+    self.updateFrames = nil
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
-        updateFrames = function()
+        self.updateFrames = function()
             if Rematch.frame:IsVisible() then
                 Rematch.frame:Update()
             end
         end
     else
-        updateFrames = function()
+        self.updateFrames = function()
             if RematchLoadedTeamPanel:IsVisible() then
                 RematchLoadedTeamPanel:Update()
             end
@@ -80,13 +80,14 @@ function RematchPlugin:SetupUI()
             end
         end
     end
-    self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', updateFrames)
+    self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', self.updateFrames)
 
     -- Button to indicate a script exists
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
         -- TODO: restore tooltip/button once Rematch supports that again
         Rematch.badges:RegisterBadge('teams', 'PetBattleScripts', scriptButtonIcon, nil, function(teamID)
-            return teamID and self:GetScript(teamID)
+            -- TODO: No need to `self:IsEnabled() and` if we properly remove on TeardownUI().
+            return self:IsEnabled() and teamID and self:GetScript(teamID)
         end)
     elseif rematchVersion >= ns.Version:New(4, 8, 10, 5) then
         self:SecureHook(RematchTeamPanel.List, 'callback', function(button, key)
@@ -205,7 +206,7 @@ function RematchPlugin:SetupUI()
         end)
     end
 
-    updateFrames()
+    self.updateFrames()
 end
 
 function RematchPlugin:TeardownUI()
@@ -238,5 +239,9 @@ function RematchPlugin:TeardownUI()
                 RematchTeamPanel.List:Update()
             end
         end
+    end
+
+    if self.updateFrames then
+        self.updateFrames()
     end
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -62,7 +62,7 @@ function RematchPlugin:SetupUI()
     end)
 
     -- Button to indicate a script exists
-    local version = ns.Version:Current()
+    local version = ns.Version:Current('Rematch')
     if version >= ns.Version:New(4, 8, 10, 5) then
         self:SecureHook(RematchTeamPanel.List, 'callback', function(button, key)
             local script = scriptButtons[button]

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -18,6 +18,7 @@ local scriptMenuItem = {
     end
 }
 
+-- Rematch4 only
 local scriptButtons = setmetatable({}, {
     __index = function(t, parent)
         local button = CreateFrame('Button', nil, parent, 'RematchFootnoteButtonTemplate') do
@@ -44,11 +45,16 @@ local scriptButtons = setmetatable({}, {
 })
 
 function RematchPlugin:SetupUI()
+    local rematchVersion = ns.Version:Current('Rematch')
+
     -- Add menu to edit script
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
+end
 
     -- When a script is added/removed, refresh the teams list.
     local updateFrames
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     updateFrames = function()
         if RematchLoadedTeamPanel:IsVisible() then
             RematchLoadedTeamPanel:Update()
@@ -61,10 +67,10 @@ function RematchPlugin:SetupUI()
             end
         end
     end
+end
     self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', updateFrames)
 
     -- Button to indicate a script exists
-    local rematchVersion = ns.Version:Current('Rematch')
     if rematchVersion >= ns.Version:New(4, 8, 10, 5) then
         self:SecureHook(RematchTeamPanel.List, 'callback', function(button, key)
             local script = scriptButtons[button]
@@ -131,6 +137,7 @@ function RematchPlugin:SetupUI()
         end)
     end
 
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     local function move(button, add)
         if not button:IsShown() then
             return 0
@@ -168,7 +175,9 @@ function RematchPlugin:SetupUI()
             script:Hide()
         end
     end)
+end
 
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     self:HookScript(RematchJournal, 'OnShow', function(self)
         CollectionsJournal:SetAttribute('UIPanelLayout-width', 870)
         UpdateUIPanelPositions()
@@ -178,7 +187,12 @@ function RematchPlugin:SetupUI()
         UpdateUIPanelPositions()
     end)
 end
+end
 
 function RematchPlugin:TeardownUI()
+    local rematchVersion = ns.Version:Current('Rematch')
+
+if rematchVersion < ns.Version:New(5, 0, 0, 0) then
     tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
+end
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -48,7 +48,8 @@ function RematchPlugin:SetupUI()
     tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
 
     -- When a script is added/removed, refresh the teams list.
-    self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', function()
+    local updateFrames
+    updateFrames = function()
         if RematchLoadedTeamPanel:IsVisible() then
             RematchLoadedTeamPanel:Update()
         end
@@ -59,11 +60,12 @@ function RematchPlugin:SetupUI()
                 RematchTeamPanel.List:Update()
             end
         end
-    end)
+    end
+    self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', updateFrames)
 
     -- Button to indicate a script exists
-    local version = ns.Version:Current('Rematch')
-    if version >= ns.Version:New(4, 8, 10, 5) then
+    local rematchVersion = ns.Version:Current('Rematch')
+    if rematchVersion >= ns.Version:New(4, 8, 10, 5) then
         self:SecureHook(RematchTeamPanel.List, 'callback', function(button, key)
             local script = scriptButtons[button]
             if self:GetScript(key) then

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -9,7 +9,7 @@ local ns = select(2, ...)
 local RematchPlugin = ns.RematchPlugin
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
 
-local teamMenu = {
+local scriptMenuItem = {
     text = L.EDITOR_CREATE_SCRIPT,
     func = function(_, key, ...)
         RematchPlugin:OpenScriptEditor(key, Rematch:GetTeamTitle(key))
@@ -43,7 +43,7 @@ local scriptButtons = setmetatable({}, {
 
 function RematchPlugin:SetupUI()
     -- Add menu to edit script
-    tinsert(Rematch:GetMenu('TeamMenu'), 6, teamMenu)
+    tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
 
     -- When a script is added/removed, refresh the teams list.
     self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE', function()
@@ -176,5 +176,5 @@ function RematchPlugin:SetupUI()
 end
 
 function RematchPlugin:TeardownUI()
-    tDeleteItem(Rematch:GetMenu('TeamMenu'), teamMenu)
+    tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
 end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -14,7 +14,7 @@ local scriptMenuItem = {
         return RematchPlugin:GetScript(key) and L.EDITOR_EDIT_SCRIPT or L.EDITOR_CREATE_SCRIPT
     end,
     func = function(_, key, ...)
-        RematchPlugin:OpenScriptEditor(key, Rematch:GetTeamTitle(key))
+        RematchPlugin:OpenScriptEditor(key, RematchPlugin:GetTitleByKey(key))
     end
 }
 

--- a/Share/Version2.lua
+++ b/Share/Version2.lua
@@ -54,7 +54,7 @@ function Share:DecodeData(data)
 end
 
 function Share:Import(code)
-    local name = code:match('# Name: (%S+)')
+    local name = code:match('# Name: ([^\n]+)')
     local data = code:match('# Data: (%S+)')
     local code = code:match('# Code Start(.+)# Code End')
 

--- a/UI/Import.lua
+++ b/UI/Import.lua
@@ -494,6 +494,10 @@ function Import:UpdateData()
         return self:ShowWarning(L.SHARE_IMPORT_STRING_INCOMPLETE)
     end
 
+    if not plugin:IsEnabled() then
+        return self:ShowWarning(L.SHARE_IMPORT_PLUGIN_NOT_ENABLED)
+    end
+
     local script = Addon:GetClass('Script'):New(data.db, plugin, data.key)
     self:SetScript(script, data.extra)
     self.PageFrame:SetPage(3)

--- a/UI/Import.lua
+++ b/UI/Import.lua
@@ -24,7 +24,6 @@ function Import:OnInitialize()
             self.data = nil
             self.EditBox:SetText('')
             self.EditBox:SetFocus()
-            self.ExtraCheck:SetChecked(true)
             self.PluginDropdown:SetValue(nil)
             self.KeyDropdown:SetValue(nil)
             self.PageFrame:SetPage(1, true)
@@ -388,12 +387,11 @@ function Import:InitPageImport(frame)
         end)
     end
 
-    local ExtraCheck = CreateFrame('CheckButton', nil, frame, 'UICheckButtonTemplate') do
-        ExtraCheck:SetPoint('BOTTOM', CoverCheck, 'TOP', 0, -3)
-        ExtraCheck:SetSize(26, 26)
-        ExtraCheck:SetHitRectInsets(0, -100, 0, 0)
-        ExtraCheck:SetFontString(ExtraCheck.text)
-        ExtraCheck:SetText(L.SHARE_IMPORT_LABEL_EXTRA)
+    local ExtraHint = frame:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall') do
+        ExtraHint:SetPoint('BOTTOM', CoverCheck, 'TOP', 0, -3)
+        ExtraHint:SetPoint('LEFT', 20, 0)
+        ExtraHint:SetPoint('RIGHT', -20, 0)
+        ExtraHint:SetText(L.SHARE_IMPORT_LABEL_HAS_EXTRA)
     end
 
     local SaveButton = CreateFrame('Button', nil, frame, 'UIPanelButtonTemplate') do
@@ -406,7 +404,7 @@ function Import:InitPageImport(frame)
     end
 
     self.CoverCheck = CoverCheck
-    self.ExtraCheck = ExtraCheck
+    self.ExtraHint = ExtraHint
     self.SaveButton = SaveButton
     self.WarningHelp = WarningHelp
     self.ScriptInfo = ScriptInfo
@@ -425,15 +423,15 @@ function Import:OnSaveButtonClick()
     self.Frame:Hide()
     self.script:GetPlugin():AddScript(self.script:GetKey(), self.script)
 
-    if self.extra and self.ExtraCheck:GetChecked() then
-        self.script:GetPlugin():OnImport(self.extra)
+    if self.extra then
+        self.script:GetPlugin():OnImport(self.script, self.extra)
     end
 end
 
 function Import:SetScript(script, extra)
     self.script = script
     self.extra  = extra
-    self.ExtraCheck:SetShown(extra)
+    self.ExtraHint:SetShown(extra)
 
     if script then
         self.ScriptInfo.Icon:SetTexture(script:GetPlugin():GetPluginIcon())
@@ -453,13 +451,13 @@ function Import:SetScript(script, extra)
 
     if extra then
         if not self.CoverCheck:IsShown() then
-            self.ExtraCheck:SetPoint('BOTTOM', self.CoverCheck, 'BOTTOM')
+            self.ExtraHint:SetPoint('BOTTOM', self.CoverCheck, 'BOTTOM')
         else
-            self.ExtraCheck:SetPoint('BOTTOM', self.CoverCheck, 'TOP', 0, -3)
+            self.ExtraHint:SetPoint('BOTTOM', self.CoverCheck, 'TOP', 0, -3)
         end
-        self.ExtraCheck:Show()
+        self.ExtraHint:Show()
     else
-        self.ExtraCheck:Hide()
+        self.ExtraHint:Hide()
     end
 
     self:UpdateControl()


### PR DESCRIPTION
This PR is based on #56 but keeps compatibility with Rematch 4. Additionally, it does some more drive-by fixes based on the open todos. Besides import logic and resolving todos it should be equivalent to what @gizzmo did if using Rematch5.

Another thing this branch does differently is trying to make the history slightly easier to read, i.e. easier to review individual commits. The "whitespace" commits are really just that and are separate in order to be ignored. The individual commits should then make sense on their own. The Rematch 5 compatibility is done in a single commit in the very end.