### PR TITLE
Fix for #73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- Import dialog no longer breaks with Rematch 5.
 - Import dialog no longer breaks with disabled plugins. If you ever disabled a plugin, please contact us to win a price.
 
 ## v1.9.3

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -200,8 +200,15 @@ function RematchPlugin:IterateKeys()
         return
     end
 
+    local iter,tbl
+    if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
+        iter,tbl = Rematch.savedTeams:AllTeams()
+    else
+        iter,tbl = pairs(RematchSaved)
+    end
+
     return coroutine.wrap(function()
-        for key in pairs(self.savedRematchTeams) do
+        for key in iter,tbl do
             coroutine.yield(key)
         end
     end)


### PR DESCRIPTION
To reproduce the error from #73 :

1. Open the import dialog.
2. Paste in a script. Not a PBS export text.
3. Notice the warning and Click continue.
4. Select the Rematch plugin.
5. Click the dropdown to select a key, (a Rematch team)
6. Error happens here.

In Rematch 5, iterating over the `Rematch.savedTeams` table will only return the methods on that table, and not the teams. Use `:AllTeams()` to iterate over all the teams.

###### This has not been tested on Rematch 4, but should work. But whos still running Rematch 4?