### PR TITLE
Found some issues with enabling/disabling plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.10
+
+### Fixes
+
+- Import dialog no longer breaks with disabled plugins. If you ever disabled a plugin, please contact us to win a price.
+
 ## v1.9.3
 
 ### Other

--- a/Core/Manager/PluginManager.lua
+++ b/Core/Manager/PluginManager.lua
@@ -183,6 +183,8 @@ end
 function PluginManager:EnableModuleWithAddonLoaded(module, addon)
     module:Disable()
 
+    module.requiredAddon = addon
+
     if not IsAddOnLoaded(addon) then
         self.moduleWatings[addon] = self.moduleWatings[addon] or {}
         tinsert(self.moduleWatings[addon], module)
@@ -202,7 +204,7 @@ function PluginManager:SetPluginAllowed(name, flag)
 
     C_Timer.After(0, function()
         local module = Addon:GetPlugin(name)
-        if flag then
+        if flag and IsAddOnLoaded(module.requiredAddon) then
             module:Enable()
         else
             module:Disable()

--- a/UI/Import.lua
+++ b/UI/Import.lua
@@ -212,7 +212,7 @@ function Import:InitPageSelector(frame)
         PluginDropdown:SetMaxItem(20)
         PluginDropdown:SetDefaultText(L.SHARE_IMPORT_CHOOSE_SELECTOR)
         PluginDropdown:SetMenuTable(function(list)
-            for _, plugin in Addon:IteratePlugins() do
+            for _, plugin in Addon:IterateEnabledPlugins() do
                 if type(plugin.IterateKeys) == 'function' then
                     tinsert(list, {
                         text = plugin:GetPluginTitle(),

--- a/UI/MainPanel.lua
+++ b/UI/MainPanel.lua
@@ -390,7 +390,7 @@ function Module:UpdateScriptList()
     end
 
     local list = {} do
-        for _, plugin in Addon:IteratePlugins() do
+        for _, plugin in Addon:IterateEnabledPlugins() do
             tinsert(list, {
                 type = 'plugin',
                 value = plugin


### PR DESCRIPTION
## In the main window, and import dialog, only enabled plugins (and their respective keys) should be listed. 
Steps to reproduce bugs:
1. With Rematch loaded, disable the plugin. 
2. See that the main window contains all the scripts. 
3. Tooltips will break.
4. Import dialog list is the same.

## When allowing a plugin to load (in the options), when the addon it requires isn't loaded, the addon shouldn't be enabled.

Steps to reproduce:
1. With Rematch not loaded, disable and Re-enable the plugin.
2. See errors.