### PR TITLE
Update badge callback arguments

### DIFF
--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -86,7 +86,7 @@ function RematchPlugin:SetupUI()
     scriptButtonIcon = scriptButtonIcon:gsub('{{REMATCHVERSION}}', rematchVersion.major)
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
         -- TODO: restore tooltip/button once Rematch supports that again
-        Rematch.badges:RegisterBadge('teams', 'PetBattleScripts', scriptButtonIcon, nil, function(teamID)
+        Rematch.badges:RegisterBadge('teams', 'PetBattleScripts', scriptButtonIcon, nil, function(_, teamID)
             return teamID and self:GetScript(teamID)
         end)
     elseif rematchVersion >= ns.Version:New(4, 8, 10, 5) then


### PR DESCRIPTION
Rematch 5.1 rewrote the badge code. And with it, added a new argument. I think it refers to the list entry. Doesn't really matter, it won't be used.