### PR TITLE
Update to ElvUI skin

### DIFF
--- a/UI/ElvUISkin.lua
+++ b/UI/ElvUISkin.lua
@@ -31,11 +31,17 @@ function S:tdBattlePetScript()
     ArtFrame2.SetShown = nop
 
     local yOffset = E.PixelMode and -1 or 1
-    local gap = E.PixelMode and 1 or 3
+    local gap = E.PixelMode and -1 or 1
     local xOffset = gap + AutoButton:GetWidth()
 
     S:HandleButton(AutoButton)
     AutoButton:SetPoint('LEFT', SkipButton,'RIGHT', gap, 0)
+    AutoButton:SetParent(SkipButton:GetParent())
+
+    -- Raise up the frame to show the border glow above the skip button's border
+    local frameLevel = AutoButton:GetFrameLevel()
+    AutoButton:HookScript("OnEnter", function(self) self:SetFrameLevel(frameLevel+1) end)
+    AutoButton:HookScript("OnLeave", function(self) self:SetFrameLevel(frameLevel) end)
 
     -- When the SkipButton is placed, make room for the AutoButton
     hooksecurefunc(SkipButton, "SetPoint", function(_, _, _, _, _, _, forced)


### PR DESCRIPTION
### This removes the gap between the Skip button and the Auto button.

I originally put the gap there because the mouseover borders were overlapping, leaving one of the buttons not showing their shared edge on mouseover. The key change was noticing that ElvUI changed the Skip button's parent after PBS creates the auto button.

I can provide screenshots if you'd like.

###### P.S. Yes I see the two variable with the same value. I couldn't think a better name for them. And it felt weird putting `yOffset` in the xoffset argument of the `AutoButton:Point` call. Also having argument variables named `xOffset` next to`yOffset` just feels better. 