### PR TITLE
Fixes references to functions moved out of global namespace in 11.0.2

### DIFF
--- a/Core/Manager/PluginManager.lua
+++ b/Core/Manager/PluginManager.lua
@@ -185,7 +185,7 @@ function PluginManager:EnableModuleWithAddonLoaded(module, addon)
 
     module.requiredAddon = addon
 
-    if not IsAddOnLoaded(addon) then
+    if not C_AddOns.IsAddOnLoaded(addon) then
         self.moduleWatings[addon] = self.moduleWatings[addon] or {}
         tinsert(self.moduleWatings[addon], module)
 

--- a/Core/Version.lua
+++ b/Core/Version.lua
@@ -18,7 +18,7 @@ function Version:Constructor(major, minor, build, revision)
 end
 
 function Version:Current(addon)
-    if GetAddOnEnableState(nil, addon) == 0 then
+    if C_AddOns.GetAddOnEnableState(addon) == 0 then
         -- Disabled addon is considered not loaded.
         return
     end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -18,7 +18,7 @@ function RematchPlugin:OnInitialize()
 
     local rematchIcon = [[Interface\AddOns\Rematch\Textures\icon]]
     local fallbackIcon = [[Interface\Icons\inv_misc_questionmark]]
-    local rematchExists = select(5, GetAddOnInfo('Rematch')) ~= 'MISSING'
+    local rematchExists = select(5, C_AddOns.GetAddOnInfo('Rematch')) ~= 'MISSING'
     self:SetPluginIcon(rematchExists and rematchIcon or fallbackIcon)
 end
 


### PR DESCRIPTION
C_AddOns.GetAddOnEnableState also helpfully fixes so the optional param is at the end, and can be omitted now.