### PR TITLE
fix: pet qualities are 0..5 now, not 1..6 (but the global constants are unchanged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.10.6
+
+### Fixes
+
+- Adapt to silent change where pet qualities are now 0…5 instead of 1…6. Scripts using `[ ….quality ]` conditions should work as expected again.
+
 ## v1.10.5
 
 ### Other

--- a/Extension/Conditions.lua
+++ b/Extension/Conditions.lua
@@ -195,7 +195,7 @@ end)
 
 
 Addon:RegisterCondition('quality', { type = 'compare', arg = false, valueParse = Util.ParseQuality }, function(owner, pet)
-    return pet and C_PetBattles.GetBreedQuality(owner, pet)
+    return pet and (C_PetBattles.GetBreedQuality(owner, pet) + 1)
 end)
 
 


### PR DESCRIPTION
- Fixes issue #99
- Breaking change in https://github.com/tomrus88/BlizzardInterfaceCode/commit/a2b6f876#diff-33ad4647e11369665574fbbe972417e1e09bbcb461abbe687e175c249d3a311fR1065