### PR TITLE
#108: deprecate Rematch4, automatically add scripts from Rematch team notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This feature works together with the [Xu-Fu](https://www.wow-petguide.com) featu
 
 This happens on login (i.e. is retroactive) and when importing a team.
 
+The other way around needs manual interaction. Use the 'Add script to note' menu item to add it until the next game session (where it will be automatically imported and removed again).
+
 ### Compatibility with Rematch 4
 
 Compatibility will be dropped this year (2025). Hopefully, nobody still uses it anyway. If you still do, please upgrade. Also, please tell us so we know whether there still actually are users of it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.0
+
+### Fixes
+
+- The notifications about (Rematch 4 to 5) database updates now actually work.
+
 ## v1.10.8
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## v1.11.0
 
+### Automatic script import from Rematch notes
+
+If a Rematch team contains a block like
+
+```
+Other text.
+-----BEGIN PET BATTLE SCRIPT-----
+standby
+change(next)
+-----END PET BATTLE SCRIPT-----
+More text.
+```
+
+the script will be automatically added, if it is valid and the team does not yet have a (different) script attached. The note will then have the script data removed.
+
+This feature works together with the [Xu-Fu](https://www.wow-petguide.com) feature which now adds this exact block on exporting teams. It is now enough to only export the teams, and no longer needed to add the script manually afterwards.
+
+This happens on login (i.e. is retroactive) and when importing a team.
+
 ### Compatibility with Rematch 4
 
 Compatibility will be dropped this year (2025). Hopefully, nobody still uses it anyway. If you still do, please upgrade. Also, please tell us so we know whether there still actually are users of it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Compatibility will be dropped this year (2025). Hopefully, nobody still uses it 
 
 - The notifications about (Rematch 4 to 5) database updates now actually work.
 
+### Other
+
+- Bumped TOC for patch 11.1.5
+
 ## v1.10.8
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.11.0
 
+### Compatibility with Rematch 4
+
+Compatibility will be dropped this year (2025). Hopefully, nobody still uses it anyway. If you still do, please upgrade. Also, please tell us so we know whether there still actually are users of it.
+
 ### Fixes
 
 - The notifications about (Rematch 4 to 5) database updates now actually work.

--- a/Core/Addon.lua
+++ b/Core/Addon.lua
@@ -79,11 +79,11 @@ function Addon:UpdateDatabase()
         self.db.global.version = newVersion
 
         C_Timer.After(0.9, function()
-            GUI:Notify{
+            GUI:Notify({
                 text = format('%s\n|cff00ffff%s: |cffffff00%s|r', ns.L.ADDON_NAME, ns.L.DATABASE_UPDATED_TO, newVersion),
                 icon = ns.ICON,
                 help = ''
-            }
+            })
         end)
     end
 end

--- a/Core/Manager/PluginManager.lua
+++ b/Core/Manager/PluginManager.lua
@@ -100,13 +100,13 @@ function PluginManager:UpdatePlugins()
 
     if found then
         C_Timer.After(1, function()
-            GUI:Notify{
+            GUI:Notify({
                 text = L.DATABASE_UPDATE_BASE_TO_FIRSTENEMY_NOTIFICATION,
                 icon = ns.ICON,
                 OnAccept = function()
                     Addon:OpenOptionsFrame()
                 end
-            }
+            })
         end)
     end
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -408,9 +408,14 @@ end
 
 local section           = 'PET BATTLE SCRIPT'
 local patternSeps       = '%-%-%-%-%-'
+local outputSeps        = '-----'
 local patternBegin      = patternSeps .. 'BEGIN ' .. section .. patternSeps
+local outputBegin       = outputSeps  .. 'BEGIN ' .. section .. outputSeps
 local patternEnd        = patternSeps .. 'END '   .. section .. patternSeps
-local patternScriptNote = '\n*' .. patternBegin .. "\n(.*)" .. patternEnd .. '\n*'
+local outputEnd         = outputSeps  .. 'END '   .. section .. outputSeps
+local patternScriptNote = '\n*' .. patternBegin .. '\n(.*)' .. patternEnd .. '\n*'
+local outputScriptNoteB = '\n'  .. outputBegin .. '\n'
+local outputScriptNoteA =                             '\n'  .. outputEnd .. '\n'
 
 function RematchPlugin:_UpdateTeamNote(key, note)
     if self.savedRematchTeams[key].notes == note then
@@ -493,4 +498,20 @@ function RematchPlugin:CheckAllTeamsForScriptsInNotes()
     for key, team in Rematch.savedTeams:AllTeams() do
         self:MaybeTakeScriptFromNotes(key, team)
     end
+end
+
+function RematchPlugin:AddScriptToNote(key)
+    local existingScript = self:GetScript(key)
+    if not existingScript then
+        return
+    end
+
+    local checkedExistingCode, err = Director:BuildScript(existingScript:GetCode())
+    if err then
+        return
+    end
+    local code = Director:BeautyScript(checkedExistingCode)
+
+    local note = self.savedRematchTeams[key].notes or ''
+    self:_UpdateTeamNote(key, note .. outputScriptNoteB .. code .. outputScriptNoteA)
 end

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -22,6 +22,14 @@ function RematchPlugin:OnInitialize()
     self:SetPluginIcon(rematchExists and rematchIcon or fallbackIcon)
 end
 
+local function runIfOnceOutOfCombat(fun)
+    if InCombatLockdown() then
+        EventUtil.RegisterOnceFrameEventAndCallback("PLAYER_REGEN_ENABLED", fun)
+    else
+        C_Timer.After(0, fun)
+    end
+end
+
 function RematchPlugin:OnEnable()
     local rematchVersion = ns.Version:Current('Rematch')
 
@@ -29,6 +37,16 @@ function RematchPlugin:OnEnable()
         self.savedRematchTeams = Rematch.savedTeams
     else
         self.savedRematchTeams = RematchSaved
+
+        C_Timer.After(1, function()
+            runIfOnceOutOfCombat(function()
+                GUI:Notify({
+                    text = format('%s\n|cff00ffff%s|r', ns.L.ADDON_NAME, ns.L.REMATCH4_DEPRECATED),
+                    icon = ns.ICON,
+                    duration = 30,
+                })
+            end)
+        end)
     end
 
     -- Team is deleted

--- a/Rematch/Addon.lua
+++ b/Rematch/Addon.lua
@@ -339,11 +339,11 @@ function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     scriptsDB.Rematch4 = CopyTable(scriptsDB.Rematch)
 
     C_Timer.After(0.9, function()
-        GUI:Notify{
+        GUI:Notify({
             text = format('%s\n|cff00ffff%s|r', ns.L.ADDON_NAME, ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_NOTE),
             icon = ns.ICON,
             duration = -1,
-        }
+        })
     end)
 
     -- First we need a cache list of all of our scripts, so we can modify our scripts
@@ -367,11 +367,11 @@ function RematchPlugin:UpdateDBRematch4To5(convertedTeams)
     for teamID, script in self:IterateScripts() do
         if not self.savedRematchTeams[teamID] then
             C_Timer.After(0.9, function()
-                GUI:Notify{
+                GUI:Notify({
                     text = format('%s\n|cff00ffff%s|r', ns.L.ADDON_NAME, format(ns.L.SELECTOR_REMATCH_4_TO_5_UPDATE_ORPHAN, script:GetName(), teamID)),
                     icon = ns.ICON,
                     duration = -1,
-                }
+                })
             end)
         end
     end

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -60,11 +60,9 @@ function RematchPlugin:SetupUI()
 
     -- Add menu to edit script
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
-        local afterText = Rematch.localization['Set Notes'] -- Use Rematch's locale string.
-        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItemAddScriptToNote, afterText)
-        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItemAddScriptToNote, afterText)
-        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItemEditScript, afterText)
-        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItemEditScript, afterText)
+        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItemEditScript, Rematch.localization['Set Notes'])
+        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItemEditScript, Rematch.localization['Set Notes'])
+        Rematch.menus:AddToMenu('ShareTeamMenu', scriptMenuItemAddScriptToNote, Rematch.localization['Plain Text'])
     else
         tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItemEditScript)
     end
@@ -229,10 +227,9 @@ function RematchPlugin:TeardownUI()
     self:UnregisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
 
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
-        tDeleteItem(Rematch.menus:GetDefinition('TeamMenu'), scriptMenuItemAddScriptToNote)
-        tDeleteItem(Rematch.menus:GetDefinition('LoadedTeamMenu'), scriptMenuItemAddScriptToNote)
         tDeleteItem(Rematch.menus:GetDefinition('TeamMenu'), scriptMenuItemEditScript)
         tDeleteItem(Rematch.menus:GetDefinition('LoadedTeamMenu'), scriptMenuItemEditScript)
+        tDeleteItem(Rematch.menus:GetDefinition('ShareTeamMenu'), scriptMenuItemAddScriptToNote)
 
         Rematch.badges:UnregisterBadge('teams', 'PetBattleScripts')
     else

--- a/Rematch/UI.lua
+++ b/Rematch/UI.lua
@@ -9,12 +9,21 @@ local ns = select(2, ...)
 local RematchPlugin = ns.RematchPlugin
 local L     = LibStub('AceLocale-3.0'):GetLocale('PetBattleScripts')
 
-local scriptMenuItem = {
+local scriptMenuItemEditScript = {
     text = function(_, key, ...)
         return RematchPlugin:GetScript(key) and L.EDITOR_EDIT_SCRIPT or L.EDITOR_CREATE_SCRIPT
     end,
     func = function(_, key, ...)
         RematchPlugin:OpenScriptEditor(key, RematchPlugin:GetTitleByKey(key))
+    end
+}
+local scriptMenuItemAddScriptToNote = {
+    hidden = function(_, key, ...)
+        return RematchPlugin:GetScript(key) == nil
+    end,
+    text = L.REMATCH_NOTE_SCRIPT_EXPORT_ADD_TO_NOTE_MENU_ITEM,
+    func = function(_, key, ...)
+        RematchPlugin:AddScriptToNote(key)
     end
 }
 
@@ -52,10 +61,12 @@ function RematchPlugin:SetupUI()
     -- Add menu to edit script
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
         local afterText = Rematch.localization['Set Notes'] -- Use Rematch's locale string.
-        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItem, afterText)
-        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItem, afterText)
+        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItemAddScriptToNote, afterText)
+        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItemAddScriptToNote, afterText)
+        Rematch.menus:AddToMenu('TeamMenu', scriptMenuItemEditScript, afterText)
+        Rematch.menus:AddToMenu('LoadedTeamMenu', scriptMenuItemEditScript, afterText)
     else
-        tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItem)
+        tinsert(Rematch:GetMenu('TeamMenu'), 6, scriptMenuItemEditScript)
     end
 
     -- When a script is added/removed, refresh the teams list.
@@ -218,14 +229,16 @@ function RematchPlugin:TeardownUI()
     self:UnregisterMessage('PET_BATTLE_SCRIPT_SCRIPT_LIST_UPDATE')
 
     if rematchVersion >= ns.Version:New(5, 0, 0, 0) then
-        tDeleteItem(Rematch.menus:GetDefinition('TeamMenu'), scriptMenuItem)
-        tDeleteItem(Rematch.menus:GetDefinition('LoadedTeamMenu'), scriptMenuItem)
+        tDeleteItem(Rematch.menus:GetDefinition('TeamMenu'), scriptMenuItemAddScriptToNote)
+        tDeleteItem(Rematch.menus:GetDefinition('LoadedTeamMenu'), scriptMenuItemAddScriptToNote)
+        tDeleteItem(Rematch.menus:GetDefinition('TeamMenu'), scriptMenuItemEditScript)
+        tDeleteItem(Rematch.menus:GetDefinition('LoadedTeamMenu'), scriptMenuItemEditScript)
 
         Rematch.badges:UnregisterBadge('teams', 'PetBattleScripts')
     else
         self:UnhookAll()
 
-        tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItem)
+        tDeleteItem(Rematch:GetMenu('TeamMenu'), scriptMenuItemEditScript)
 
         for _, frame in pairs(scriptButtons) do
             frame:ClearAllPoints()

--- a/tdBattlePetScript.toc
+++ b/tdBattlePetScript.toc
@@ -1,4 +1,4 @@
-## Interface: 110100
+## Interface: 110105
 ## Title: Pet Battle Scripts
 ## Notes: Battle Pet Combat Scripting
 ## Author: axc450


### PR DESCRIPTION
### Automatic script import from Rematch notes

If a Rematch team contains a block like

```
Other text.
-----BEGIN PET BATTLE SCRIPT-----
standby
change(next)
-----END PET BATTLE SCRIPT-----
More text.
```

the script will be automatically added, if it is valid and the team does not yet have a (different) script attached. The note will then have the script data removed.

This feature works together with the [Xu-Fu](https://www.wow-petguide.com) feature which now adds this exact block on exporting teams. It is now enough to only export the teams, and no longer needed to add the script manually afterwards.

This happens on login (i.e. is retroactive) and when importing a team.

### Compatibility with Rematch 4

Compatibility will be dropped this year (2025). Hopefully, nobody still uses it anyway. If you still do, please upgrade. Also, please tell us so we know whether there still actually are users of it.

### Fixes

- The notifications about (Rematch 4 to 5) database updates now actually work.

-------------

Closes #108.