### PR TITLE
allow having two hotkeys for the auto button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.3
+
+### Other
+
+- Allow specifying a secondary hotkey for the auto button.
+
 ## v1.11.2
 
 ### Fixes

--- a/UI/Options.lua
+++ b/UI/Options.lua
@@ -114,7 +114,8 @@ function Options:UpdateOptions()
     local optionsArgs = wipe(self.optionsArgs)
 
     --- General
-    optionsArgs.autoButtonHotKey = makeKeybinding(L.OPTION_AUTOBUTTON_HOTKEY)
+    optionsArgs.autoButtonHotKey = makeKeybinding(L.OPTION_AUTOBUTTON_HOTKEY, {width='double'})
+    optionsArgs.autoButtonHotKey2 = makeKeybinding(L.OPTION_AUTOBUTTON_HOTKEY_SECONDARY, {width='fill'})
     optionsArgs.notifyButtonActive = makeToggle(L.OPTION_NOTIFY_BUTTON_ACTIVE, {width = 'double'})
     optionsArgs.notifyButtonActivePadding = makePadding(0.2)
     optionsArgs.notifyButtonActiveSound = makeSelect(L.OPTION_NOTIFY_BUTTON_ACTIVE_SOUND, LibSharedMedia.MediaType.SOUND, {width = 'normal',})

--- a/UI/PetBattle.lua
+++ b/UI/PetBattle.lua
@@ -215,6 +215,7 @@ function Module:OnEnable()
     self:RegisterMessage('PET_BATTLE_SCRIPT_SCRIPT_UPDATE', 'UpdateAutoButton')
 
     self:RegisterMessage('PET_BATTLE_SCRIPT_SETTING_CHANGED_autoButtonHotKey', 'UpdateHotKey')
+    self:RegisterMessage('PET_BATTLE_SCRIPT_SETTING_CHANGED_autoButtonHotKey2', 'UpdateHotKey')
     self:RegisterMessage('PET_BATTLE_SCRIPT_SETTING_CHANGED_lockScriptSelector', 'UpdateLocked')
 
     self:RegisterMessage('PET_BATTLE_SCRIPT_RESET_FRAMES')
@@ -255,10 +256,18 @@ function Module:UpdateHotKey()
 
     ClearOverrideBindings(self.AutoButton)
 
-    local hotKey = Addon:GetSetting('autoButtonHotKey')
-    if hotKey then
-        SetOverrideBindingClick(self.AutoButton, true, hotKey, self.AutoButton:GetName())
-        self.AutoButton.HotKey:SetText(hotKey)
+    local hotKey1 = Addon:GetSetting('autoButtonHotKey')
+    local hotKey2 = Addon:GetSetting('autoButtonHotKey2')
+    if hotKey1 ~= "" and hotKey2 ~= "" then
+        SetOverrideBindingClick(self.AutoButton, true, hotKey1, self.AutoButton:GetName())
+        SetOverrideBindingClick(self.AutoButton, true, hotKey2, self.AutoButton:GetName())
+        self.AutoButton.HotKey:SetText(hotKey1 .. '/' .. hotKey2)
+    elseif hotKey1 ~= "" then
+        SetOverrideBindingClick(self.AutoButton, true, hotKey1, self.AutoButton:GetName())
+        self.AutoButton.HotKey:SetText(hotKey1)
+    elseif hotKey2 ~= "" then
+        SetOverrideBindingClick(self.AutoButton, true, hotKey2, self.AutoButton:GetName())
+        self.AutoButton.HotKey:SetText(hotKey2)
     else
         self.AutoButton.HotKey:SetText('')
     end


### PR DESCRIPTION
New localisation: `OPTION_AUTOBUTTON_HOTKEY_SECONDARY` which should be a short indicator that the key bind is an optional alternative, e.g. 
<img width="925" alt="image" src="https://github.com/user-attachments/assets/f96f3c88-562b-41b4-bc44-82ebe679f080" />

Closes #87.
