### PR TITLE
Allow closing script editor/list with escape.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.3
+
+### Other
+
+- Allow closing script editor/list with escape.
+
 ## v1.11.2
 
 ### Fixes

--- a/UI/MainPanel.lua
+++ b/UI/MainPanel.lua
@@ -49,6 +49,9 @@ function Module:OnInitialize()
         MainPanel:SetAttribute('UIPanelLayout-pushable', 1)
     end
 
+    _G["PetBattleScripts_MainPanel"] = MainPanel
+    tinsert(UISpecialFrames, "PetBattleScripts_MainPanel")
+
     local Inset = CreateFrame('Frame', nil, MainPanel, 'InsetFrameTemplate') do
         Inset:SetPoint('TOPLEFT', 4, -60)
         Inset:SetPoint('BOTTOMRIGHT', -6, 26)


### PR DESCRIPTION
Closes #83.